### PR TITLE
feat: Clicking title on article card shows the full article

### DIFF
--- a/src/lib/api/articles.ts
+++ b/src/lib/api/articles.ts
@@ -1,5 +1,10 @@
-import type { ArticleSearchResponse, SearchOptions } from './types';
+import type { Article, ArticleSearchResponse, SearchOptions } from './types';
 import { apiFetch } from './fetch';
+
+export async function fetchArticleById(id: string): Promise<Article> {
+	const response = await apiFetch(`/api/v1/articles/${id}`);
+	return response.json();
+}
 
 export async function searchArticles({
 	query,

--- a/src/lib/api/openapi.yaml
+++ b/src/lib/api/openapi.yaml
@@ -116,6 +116,52 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /articles/{public_id}:
+    get:
+      summary: Get article by ID
+      description: Retrieve a single article by its public UUID, with full text, entities, and classifications.
+      operationId: getArticle
+      tags:
+        - Articles
+      parameters:
+        - name: public_id
+          in: path
+          required: true
+          description: Public UUID of the article
+          schema:
+            type: string
+            format: uuid
+          example: 550e8400-e29b-41d4-a716-446655440000
+
+      responses:
+        '200':
+          description: Article found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Article'
+
+        '404':
+          description: Article not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+        '422':
+          description: Invalid UUID format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+        '500':
+          description: Database/server errors
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /entities:
     get:
       summary: List entities

--- a/src/lib/components/features/ArticleCard.svelte
+++ b/src/lib/components/features/ArticleCard.svelte
@@ -1,51 +1,13 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
-	import { Badge } from '$lib/components/ui/badge';
-	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { resolve } from '$app/paths';
 	import type { Article } from '$lib/api/types';
-	import gleanerIcon from '$lib/assets/gleaner-article-card-icon.png';
-	import observerIcon from '$lib/assets/observer-article-card-icon.png';
-	import fallbackIcon from '$lib/assets/fallback-article-card-icon.png';
+	import ArticleSourceHeader from './ArticleSourceHeader.svelte';
 
 	let { article, onTopicClick }: { article: Article; onTopicClick?: (entity: string) => void } =
 		$props();
 
 	const classification = $derived(article.classifications[0]);
-	const confidenceDisplay = $derived(
-		classification ? `${Math.round(classification.confidenceScore * 100)}%` : null
-	);
-
-	// Confidence pill styling - color ranges from yellow (0.7) to green (1.0)
-	const confidencePillClasses = $derived(() => {
-		const base = 'inline-flex items-center rounded-full border px-3 py-1 text-sm font-semibold';
-		if (!classification) return `${base} bg-neutral-50 text-neutral-600 border-neutral-200`;
-		const confidence = classification.confidenceScore;
-		if (confidence >= 0.9) return `${base} bg-green-100 text-green-700 border-green-400`;
-		if (confidence >= 0.8) return `${base} bg-green-50 text-green-500 border-green-200`;
-		return `${base} bg-gold-50 text-gold-700 border-gold-200`;
-	});
-
-	// Format the published date
-	const formattedDate = $derived(() => {
-		const date = new Date(article.publishedDate);
-		return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-	});
-
-	const sourceIcon = $derived(
-		article.newsSource === 'JAMAICA_GLEANER'
-			? gleanerIcon
-			: article.newsSource === 'JAMAICA_OBSERVER'
-				? observerIcon
-				: fallbackIcon
-	);
-
-	const sourceName = $derived(
-		article.newsSource === 'JAMAICA_GLEANER'
-			? 'Jamaica Gleaner'
-			: article.newsSource === 'JAMAICA_OBSERVER'
-				? 'Jamaica Observer'
-				: 'Source'
-	);
 
 	type TextPart = { text: string; highlighted: boolean };
 	type FocusedSentence = { text: string; parts: TextPart[] };
@@ -165,62 +127,19 @@
 
 <Card.Root class="overflow-hidden shadow-sm transition-shadow duration-200 hover:shadow-md">
 	<Card.Header class="pb-3">
-		<div class="flex items-start justify-between gap-4">
-			<!-- Left: Source + Date + Badge -->
-			<div class="flex items-center gap-3">
-				<img
-					src={sourceIcon}
-					alt={sourceName}
-					class="h-9 w-9 rounded-sm object-cover"
-					loading="lazy"
-				/>
-				<div>
-					<div class="text-sm font-medium text-muted-foreground">{sourceName}</div>
-					<time datetime={article.publishedDate} class="text-xs text-muted-foreground">
-						{formattedDate()}
-					</time>
-					{#if classification}
-						<Tooltip.Root>
-							<Tooltip.Trigger class="mt-1 block w-fit">
-								<Badge variant="destructive" class="capitalize">
-									{classification.classifierType.toLowerCase()}
-								</Badge>
-							</Tooltip.Trigger>
-							<Tooltip.Content>
-								<p>
-									This label shows what kind of accountability issue our AI identified in this
-									article.
-								</p>
-							</Tooltip.Content>
-						</Tooltip.Root>
-					{/if}
-				</div>
-			</div>
-
-			<!-- Right: Certainty pill -->
-			{#if confidenceDisplay}
-				<Tooltip.Root>
-					<Tooltip.Trigger>
-						<span class={confidencePillClasses()}>
-							Certainty <strong class="ml-1">{confidenceDisplay}</strong>
-						</span>
-					</Tooltip.Trigger>
-					<Tooltip.Content>
-						<p>
-							How certain the AI is that this article belongs to this category. Scores above 80% are
-							considered high certainty.
-						</p>
-					</Tooltip.Content>
-				</Tooltip.Root>
-			{/if}
-		</div>
+		<ArticleSourceHeader {article} />
 	</Card.Header>
 
 	<Card.Content class="space-y-4 px-4 sm:px-6">
 		<!-- Title -->
 		<div>
 			<h3 class="text-lg font-semibold leading-tight text-card-foreground md:text-xl">
-				{article.title}
+				<a
+					href={resolve(`/articles/${article.id}`)}
+					class="hover:underline hover:text-accent-hover"
+				>
+					{article.title}
+				</a>
 			</h3>
 		</div>
 

--- a/src/lib/components/features/ArticleDetailView.svelte
+++ b/src/lib/components/features/ArticleDetailView.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card';
+	import { resolve } from '$app/paths';
+	import type { Article } from '$lib/api/types';
+	import ArticleSourceHeader from './ArticleSourceHeader.svelte';
+
+	let { article }: { article: Article } = $props();
+
+	const paragraphs = $derived(
+		article.fullText
+			? article.fullText
+					.split('\n\n')
+					.map((p) => p.trim())
+					.filter((p) => p.length > 0)
+			: []
+	);
+</script>
+
+<main class="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:max-w-5xl lg:py-16">
+	<a
+		href="{resolve('/')}#search"
+		class="mt-6 mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-accent-hover"
+	>
+		← Back to articles
+	</a>
+
+	<Card.Root class="shadow-sm">
+		<Card.Header class="pb-3">
+			<ArticleSourceHeader {article} />
+		</Card.Header>
+
+		<Card.Content class="space-y-6 px-4 sm:px-6">
+			<!-- Title -->
+			<h1 class="text-2xl font-bold leading-tight text-foreground md:text-3xl">
+				{article.title}
+			</h1>
+
+			<!-- Mentioned entities -->
+			{#if article.entities.length > 0}
+				<div>
+					<h2 class="mb-2 text-sm font-semibold text-neutral-500">Mentioned</h2>
+					<div class="flex flex-wrap gap-2">
+						{#each article.entities as entity (entity)}
+							<span
+								class="rounded-md border border-border bg-muted px-2 py-1 text-xs text-muted-foreground"
+							>
+								{entity}
+							</span>
+						{/each}
+					</div>
+				</div>
+			{/if}
+
+			<!-- Full article text -->
+			<div>
+				<h2 class="mb-3 text-sm font-semibold text-neutral-500">Full Article</h2>
+				{#if paragraphs.length > 0}
+					<div class="space-y-4 text-md leading-7 text-foreground">
+						{#each paragraphs as paragraph, i (i)}
+							<p>{paragraph}</p>
+						{/each}
+					</div>
+				{:else}
+					<p class="text-sm italic text-muted-foreground">Full article text is not available.</p>
+				{/if}
+			</div>
+
+			<!-- eslint-disable svelte/no-navigation-without-resolve -- External link -->
+			<a
+				href={article.url}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="text-sm font-medium text-primary underline hover:text-accent-hover"
+			>
+				Read original article →
+			</a>
+			<!-- eslint-enable svelte/no-navigation-without-resolve -->
+		</Card.Content>
+	</Card.Root>
+</main>

--- a/src/lib/components/features/ArticleDetailView.test.ts
+++ b/src/lib/components/features/ArticleDetailView.test.ts
@@ -1,0 +1,191 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import ArticleDetailView from './ArticleDetailView.svelte';
+import type { Article } from '$lib/api/types';
+
+const gleanerArticle: Article = {
+	id: 'a3f5e8c0-e29b-41d4-a716-446655440001',
+	url: 'https://jamaica-gleaner.com/article/news/test',
+	title: 'Court Rejects Claims of Nullity in Fraud Case',
+	section: 'news',
+	newsSource: 'JAMAICA_GLEANER',
+	publishedDate: '2025-11-18T09:15:00Z',
+	snippet: 'The court has rejected arguments for nullity in the high-profile fraud case.',
+	entities: ['Fritz Pinnock', 'Caribbean Maritime University', 'Financial Investigations Division'],
+	classifications: [
+		{
+			classifierType: 'CORRUPTION',
+			confidenceScore: 0.92,
+			reasoning: 'Article covers criminal fraud charges against government officials.'
+		}
+	],
+	fullText:
+		'First paragraph about the court ruling.\n\nSecond paragraph with more detail on the case.\n\nThird paragraph concluding the story.'
+};
+
+const observerArticle: Article = {
+	...gleanerArticle,
+	id: 'b7c2d9f1-f3a4-42e5-b827-557766551112',
+	url: 'https://jamaica-observer.com/article/news/test',
+	newsSource: 'JAMAICA_OBSERVER',
+	classifications: [{ classifierType: 'FRAUD', confidenceScore: 0.78 }]
+};
+
+const unknownSourceArticle: Article = {
+	...gleanerArticle,
+	newsSource: 'OTHER_SOURCE'
+};
+
+describe('ArticleDetailView', () => {
+	it('should render the article title as a heading', () => {
+		// Given: the component renders with an article
+		render(ArticleDetailView, { props: { article: gleanerArticle } });
+
+		// When: the page loads
+
+		// Then: should display the title as an h1
+		expect(
+			screen.getByRole('heading', { level: 1, name: gleanerArticle.title })
+		).toBeInTheDocument();
+	});
+
+	it('should render entity pills with Mentioned heading', () => {
+		// Given: the component renders with an article that has entities
+		render(ArticleDetailView, { props: { article: gleanerArticle } });
+
+		// When: the page loads
+
+		// Then: should display the Mentioned heading
+		expect(screen.getByText('Mentioned')).toBeInTheDocument();
+
+		// And: should display each entity
+		gleanerArticle.entities.forEach((entity) => {
+			expect(screen.getByText(entity)).toBeInTheDocument();
+		});
+	});
+
+	it('should not render the Mentioned section when entities array is empty', () => {
+		// Given: the component renders with an article that has no entities
+		render(ArticleDetailView, { props: { article: { ...gleanerArticle, entities: [] } } });
+
+		// When: the page loads
+
+		// Then: should not display the Mentioned section
+		expect(screen.queryByText('Mentioned')).not.toBeInTheDocument();
+	});
+
+	it('should render full text paragraphs when fullText is present', () => {
+		// Given: the component renders with an article that has fullText
+		render(ArticleDetailView, { props: { article: gleanerArticle } });
+
+		// When: the page loads
+
+		// Then: should display each paragraph
+		expect(screen.getByText('First paragraph about the court ruling.')).toBeInTheDocument();
+		expect(screen.getByText('Second paragraph with more detail on the case.')).toBeInTheDocument();
+		expect(screen.getByText('Third paragraph concluding the story.')).toBeInTheDocument();
+	});
+
+	it('should render fallback text when fullText is absent', () => {
+		// Given: the component renders with an article that has no fullText
+		render(ArticleDetailView, { props: { article: { ...gleanerArticle, fullText: undefined } } });
+
+		// When: the page loads
+
+		// Then: should display the fallback message
+		expect(screen.getByText('Full article text is not available.')).toBeInTheDocument();
+	});
+
+	it('should render the read original article link with correct attributes', () => {
+		// Given: the component renders with an article
+		render(ArticleDetailView, { props: { article: gleanerArticle } });
+
+		// When: the page loads
+
+		// Then: should display the link pointing to the original article URL
+		const link = screen.getByRole('link', { name: 'Read original article →' });
+		expect(link).toBeInTheDocument();
+		expect(link).toHaveAttribute('href', gleanerArticle.url);
+		expect(link).toHaveAttribute('target', '_blank');
+		expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+	});
+
+	it('should render the back to articles link pointing to /#search', () => {
+		// Given: the component renders with an article
+		render(ArticleDetailView, { props: { article: gleanerArticle } });
+
+		// When: the page loads
+
+		// Then: should display a back link to the search section
+		const backLink = screen.getByRole('link', { name: '← Back to articles' });
+		expect(backLink).toBeInTheDocument();
+		expect(backLink).toHaveAttribute('href', '/#search');
+	});
+
+	it('should render the classification badge and confidence pill', () => {
+		// Given: the component renders with an article that has a classification
+		render(ArticleDetailView, { props: { article: gleanerArticle } });
+
+		// When: the page loads
+
+		// Then: should display the classification badge in lowercase
+		expect(screen.getByText('corruption')).toBeInTheDocument();
+
+		// And: should display the certainty pill with the correct score
+		expect(screen.getByText('Certainty')).toBeInTheDocument();
+		expect(screen.getByText('92%')).toBeInTheDocument();
+	});
+
+	it('should not render badge or certainty pill when classifications is empty', () => {
+		// Given: the component renders with an article with no classifications
+		render(ArticleDetailView, { props: { article: { ...gleanerArticle, classifications: [] } } });
+
+		// When: the page loads
+
+		// Then: should not display a badge or certainty pill
+		expect(screen.queryByText('corruption')).not.toBeInTheDocument();
+		expect(screen.queryByText('Certainty')).not.toBeInTheDocument();
+	});
+
+	it('should render the Jamaica Gleaner source logo', () => {
+		// Given: the component renders with a Gleaner article
+		render(ArticleDetailView, { props: { article: gleanerArticle } });
+
+		// When: the page loads
+
+		// Then: should display the Gleaner logo and source name
+		expect(screen.getByAltText('Jamaica Gleaner')).toBeInTheDocument();
+		expect(screen.getByText('Jamaica Gleaner')).toBeInTheDocument();
+	});
+
+	it('should render the Jamaica Observer source logo', () => {
+		// Given: the component renders with an Observer article
+		render(ArticleDetailView, { props: { article: observerArticle } });
+
+		// When: the page loads
+
+		// Then: should display the Observer logo and source name
+		expect(screen.getByAltText('Jamaica Observer')).toBeInTheDocument();
+		expect(screen.getByText('Jamaica Observer')).toBeInTheDocument();
+	});
+
+	it('should render the fallback source logo for an unknown news source', () => {
+		// Given: the component renders with an article from an unknown source
+		render(ArticleDetailView, { props: { article: unknownSourceArticle } });
+
+		// When: the page loads
+
+		// Then: should display the fallback logo with generic alt text
+		expect(screen.getByAltText('Source')).toBeInTheDocument();
+	});
+
+	it('should not render published date when publishedDate is absent', () => {
+		// Given: the component renders with an article with no publishedDate
+		render(ArticleDetailView, { props: { article: { ...gleanerArticle, publishedDate: '' } } });
+
+		// When: the page loads
+
+		// Then: should not render a time element
+		expect(screen.queryByRole('time')).not.toBeInTheDocument();
+	});
+});

--- a/src/lib/components/features/ArticleSourceHeader.svelte
+++ b/src/lib/components/features/ArticleSourceHeader.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { Badge } from '$lib/components/ui/badge';
+	import * as Tooltip from '$lib/components/ui/tooltip';
+	import type { Article } from '$lib/api/types';
+	import gleanerIcon from '$lib/assets/gleaner-article-card-icon.png';
+	import observerIcon from '$lib/assets/observer-article-card-icon.png';
+	import fallbackIcon from '$lib/assets/fallback-article-card-icon.png';
+
+	let { article }: { article: Article } = $props();
+
+	const classification = $derived(article.classifications[0]);
+	const confidenceDisplay = $derived(
+		classification ? `${Math.round(classification.confidenceScore * 100)}%` : null
+	);
+
+	const confidencePillClasses = $derived(() => {
+		const base = 'inline-flex items-center rounded-full border px-3 py-1 text-sm font-semibold';
+		if (!classification) return `${base} bg-neutral-50 text-neutral-600 border-neutral-200`;
+		const confidence = classification.confidenceScore;
+		if (confidence >= 0.9) return `${base} bg-green-100 text-green-700 border-green-400`;
+		if (confidence >= 0.8) return `${base} bg-green-50 text-green-500 border-green-200`;
+		return `${base} bg-gold-50 text-gold-700 border-gold-200`;
+	});
+
+	const formattedDate = $derived(() => {
+		if (!article.publishedDate) return '';
+		const date = new Date(article.publishedDate);
+		return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+	});
+
+	const sourceIcon = $derived(
+		article.newsSource === 'JAMAICA_GLEANER'
+			? gleanerIcon
+			: article.newsSource === 'JAMAICA_OBSERVER'
+				? observerIcon
+				: fallbackIcon
+	);
+
+	const sourceName = $derived(
+		article.newsSource === 'JAMAICA_GLEANER'
+			? 'Jamaica Gleaner'
+			: article.newsSource === 'JAMAICA_OBSERVER'
+				? 'Jamaica Observer'
+				: 'Source'
+	);
+</script>
+
+<div class="flex items-start justify-between gap-4">
+	<div class="flex items-center gap-3">
+		<img src={sourceIcon} alt={sourceName} class="h-9 w-9 rounded-sm object-cover" loading="lazy" />
+		<div>
+			<div class="text-sm font-medium text-muted-foreground">{sourceName}</div>
+			{#if article.publishedDate}
+				<time datetime={article.publishedDate} class="text-xs text-muted-foreground">
+					{formattedDate()}
+				</time>
+			{/if}
+			{#if classification}
+				<Tooltip.Root>
+					<Tooltip.Trigger class="mt-1 block w-fit">
+						<Badge variant="destructive" class="capitalize">
+							{classification.classifierType.toLowerCase()}
+						</Badge>
+					</Tooltip.Trigger>
+					<Tooltip.Content>
+						<p>
+							This label shows what kind of accountability issue our AI identified in this article.
+						</p>
+					</Tooltip.Content>
+				</Tooltip.Root>
+			{/if}
+		</div>
+	</div>
+
+	{#if confidenceDisplay}
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				<span class={confidencePillClasses()}>
+					Certainty <strong class="ml-1">{confidenceDisplay}</strong>
+				</span>
+			</Tooltip.Trigger>
+			<Tooltip.Content>
+				<p>
+					How certain the AI is that this article belongs to this category. Scores above 80% are
+					considered high certainty.
+				</p>
+			</Tooltip.Content>
+		</Tooltip.Root>
+	{/if}
+</div>

--- a/src/lib/components/features/ArticleSourceHeader.test.ts
+++ b/src/lib/components/features/ArticleSourceHeader.test.ts
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import ArticleSourceHeader from './ArticleSourceHeader.svelte';
+import type { Article } from '$lib/api/types';
+
+const gleanerArticle: Article = {
+	id: 'test-gleaner-1',
+	url: 'https://jamaica-gleaner.com/article/test',
+	title: 'Test Article',
+	section: 'news',
+	newsSource: 'JAMAICA_GLEANER',
+	publishedDate: '2025-11-18T09:15:00Z',
+	snippet: 'Test snippet.',
+	entities: ['Entity One'],
+	classifications: [{ classifierType: 'CORRUPTION', confidenceScore: 0.92 }]
+};
+
+const observerArticle: Article = {
+	...gleanerArticle,
+	newsSource: 'JAMAICA_OBSERVER',
+	classifications: [{ classifierType: 'FRAUD', confidenceScore: 0.78 }]
+};
+
+const unknownSourceArticle: Article = {
+	...gleanerArticle,
+	newsSource: 'OTHER_SOURCE'
+};
+
+describe('ArticleSourceHeader', () => {
+	it('should render the Jamaica Gleaner logo and source name', () => {
+		// Given: an article from Jamaica Gleaner
+		render(ArticleSourceHeader, { props: { article: gleanerArticle } });
+
+		// When: the component renders
+
+		// Then: should display the Gleaner logo and source name
+		expect(screen.getByAltText('Jamaica Gleaner')).toBeInTheDocument();
+		expect(screen.getByText('Jamaica Gleaner')).toBeInTheDocument();
+	});
+
+	it('should render the Jamaica Observer logo and source name', () => {
+		// Given: an article from Jamaica Observer
+		render(ArticleSourceHeader, { props: { article: observerArticle } });
+
+		// When: the component renders
+
+		// Then: should display the Observer logo and source name
+		expect(screen.getByAltText('Jamaica Observer')).toBeInTheDocument();
+		expect(screen.getByText('Jamaica Observer')).toBeInTheDocument();
+	});
+
+	it('should render the fallback logo for an unknown news source', () => {
+		// Given: an article from an unknown source
+		render(ArticleSourceHeader, { props: { article: unknownSourceArticle } });
+
+		// When: the component renders
+
+		// Then: should display the fallback logo with generic alt text and label
+		expect(screen.getByAltText('Source')).toBeInTheDocument();
+		expect(screen.getByText('Source')).toBeInTheDocument();
+	});
+
+	it('should render the published date when present', () => {
+		// Given: an article with a published date
+		render(ArticleSourceHeader, { props: { article: gleanerArticle } });
+
+		// When: the component renders
+
+		// Then: should display the formatted date
+		expect(screen.getByRole('time')).toBeInTheDocument();
+		expect(screen.getByRole('time')).toHaveTextContent('Nov 18, 2025');
+	});
+
+	it('should not render the published date when absent', () => {
+		// Given: an article with no published date
+		render(ArticleSourceHeader, { props: { article: { ...gleanerArticle, publishedDate: '' } } });
+
+		// When: the component renders
+
+		// Then: should not render a time element
+		expect(screen.queryByRole('time')).not.toBeInTheDocument();
+	});
+
+	it('should render the classification badge when present', () => {
+		// Given: an article with a classification
+		render(ArticleSourceHeader, { props: { article: gleanerArticle } });
+
+		// When: the component renders
+
+		// Then: should display the badge in lowercase
+		expect(screen.getByText('corruption')).toBeInTheDocument();
+	});
+
+	it('should render the confidence pill with the correct score', () => {
+		// Given: an article with a classification confidence score
+		render(ArticleSourceHeader, { props: { article: gleanerArticle } });
+
+		// When: the component renders
+
+		// Then: should display Certainty and the rounded percentage
+		expect(screen.getByText('Certainty')).toBeInTheDocument();
+		expect(screen.getByText('92%')).toBeInTheDocument();
+	});
+
+	it('should not render the badge or confidence pill when classifications is empty', () => {
+		// Given: an article with no classifications
+		render(ArticleSourceHeader, { props: { article: { ...gleanerArticle, classifications: [] } } });
+
+		// When: the component renders
+
+		// Then: should not display a badge or confidence pill
+		expect(screen.queryByText('corruption')).not.toBeInTheDocument();
+		expect(screen.queryByText('Certainty')).not.toBeInTheDocument();
+	});
+});

--- a/src/lib/mocks/handlers/articles.ts
+++ b/src/lib/mocks/handlers/articles.ts
@@ -1,8 +1,28 @@
 import { http, HttpResponse, delay } from 'msw';
-import type { ArticleSearchResponse } from '$lib/api/types';
+import type { Article, ArticleSearchResponse, ErrorResponse } from '$lib/api/types';
 import { mockArticles } from '../fixtures/articles';
 
 export const articleHandlers = [
+	http.get<{ id: string }, never, Article | ErrorResponse>(
+		'*/api/v1/articles/:id',
+		async ({ params }) => {
+			const article = mockArticles.find((a) => a.id === params.id);
+
+			if (!article) {
+				return HttpResponse.json(
+					{ error: 'NOT_FOUND', message: 'Article not found' },
+					{ status: 404 }
+				);
+			}
+
+			if (!import.meta.env.TEST) {
+				await delay(300);
+			}
+
+			return HttpResponse.json(article);
+		}
+	),
+
 	http.get<never, never, ArticleSearchResponse>('*/api/v1/articles', async ({ request }) => {
 		const url = new URL(request.url);
 		const q = url.searchParams.get('q');

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
 	import posthog from 'posthog-js';
 	import favicon from '$lib/assets/favicon-96x96.png';
 	import Header from '$lib/components/features/Header.svelte';
+	import Footer from '$lib/components/features/Footer.svelte';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import '../app.css';
 
@@ -32,4 +33,7 @@
 		<Header />
 	{/if}
 	{@render children()}
+	{#if !page.error}
+		<Footer />
+	{/if}
 </Tooltip.Provider>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,6 @@
 	import FeaturesSection from '$lib/components/features/FeaturesSection.svelte';
 	import FAQSection from '$lib/components/features/FAQSection.svelte';
 	import ShareSection from '$lib/components/features/ShareSection.svelte';
-	import Footer from '$lib/components/features/Footer.svelte';
 	import { untrack } from 'svelte';
 	import type { Article, EntitySummary, EntitySortOrder } from '$lib/api/types';
 	import type { PageData } from './$types';
@@ -162,5 +161,4 @@
 	<FeaturesSection />
 	<FAQSection />
 	<ShareSection />
-	<Footer />
 </main>

--- a/src/routes/articles/[id]/+page.server.ts
+++ b/src/routes/articles/[id]/+page.server.ts
@@ -1,0 +1,22 @@
+import type { PageServerLoad } from './$types';
+import type { Article } from '$lib/api/types';
+import { error } from '@sveltejs/kit';
+import { env as privateEnv } from '$env/dynamic/private';
+import { env as publicEnv } from '$env/dynamic/public';
+
+export const load: PageServerLoad = async ({ fetch, params }) => {
+	const base = privateEnv.INTERNAL_API_BASE_URL ?? publicEnv.PUBLIC_API_BASE_URL ?? '';
+
+	const res = await fetch(`${base}/api/v1/articles/${params.id}`);
+
+	if (res.status === 404 || res.status === 422) {
+		throw error(404, 'Article not found');
+	}
+
+	if (!res.ok) {
+		throw error(500, 'Failed to load article');
+	}
+
+	const article: Article = await res.json();
+	return { article };
+};

--- a/src/routes/articles/[id]/+page.svelte
+++ b/src/routes/articles/[id]/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import ArticleDetailView from '$lib/components/features/ArticleDetailView.svelte';
+	import type { PageData } from './$types';
+	import { page } from '$app/state';
+
+	let { data }: { data: PageData } = $props();
+
+	const description = $derived(
+		data.article.snippet
+			? data.article.snippet.replace(/<[^>]+>/g, '')
+			: `Read the full article: ${data.article.title}`
+	);
+</script>
+
+<svelte:head>
+	<title>{data.article.title} | JAccountable</title>
+	<meta name="description" content={description} />
+
+	<!-- Open Graph -->
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content={data.article.title} />
+	<meta property="og:description" content={description} />
+	<meta property="og:url" content={page.url.href} />
+	{#if data.article.publishedDate}
+		<meta property="article:published_time" content={data.article.publishedDate} />
+	{/if}
+	{#each data.article.entities as entity (entity)}
+		<meta property="article:tag" content={entity} />
+	{/each}
+
+	<!-- Twitter -->
+	<meta name="twitter:card" content="summary" />
+	<meta name="twitter:title" content={data.article.title} />
+	<meta name="twitter:description" content={description} />
+</svelte:head>
+
+<ArticleDetailView article={data.article} />


### PR DESCRIPTION
Clicking an article card title navigates to a new /articles/[id] page showing the full article text, original source link, related entities, and related articles. Entity buttons on the detail page navigate back to the home page with that entity pre-filtered.

Issues:
closes #96