### PR TITLE
refactor: rename "Excerpt" label to "Preview" on article card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ vite.config.ts.timestamp-*
 
 # IDE
 .idea
+
+# Claude Code
+.claude/worktrees/

--- a/src/lib/components/features/home/ArticleCard.svelte
+++ b/src/lib/components/features/home/ArticleCard.svelte
@@ -163,7 +163,7 @@
 
 		<!-- Excerpt -->
 		<div>
-			<h4 class="mb-1 text-sm font-semibold text-accent">Excerpt</h4>
+			<h4 class="mb-1 text-sm font-semibold text-accent">Preview</h4>
 			<div class="max-w-prose space-y-1 text-sm leading-relaxed text-muted-foreground">
 				{#each excerpt.sentences as sentence, i (i)}
 					<!-- prettier-ignore: inline blocks are intentional — whitespace between them appears as visible text -->

--- a/src/lib/components/features/home/ArticleCard.test.ts
+++ b/src/lib/components/features/home/ArticleCard.test.ts
@@ -60,8 +60,8 @@ function assertArticleCardContent(article: Article) {
 		expect(screen.getByText('Certainty')).toBeInTheDocument();
 	}
 
-	// Excerpt section label displayed
-	expect(screen.getByText('Excerpt')).toBeInTheDocument();
+	// Preview section label displayed
+	expect(screen.getByText('Preview')).toBeInTheDocument();
 
 	// Entity badges in Mentioned section
 	article.entities.forEach((entity) => {


### PR DESCRIPTION
closes #132 