### PR TITLE
feat(home): display site metrics in hero with shimmer and count-up

### DIFF
--- a/src/lib/api/articles.test.ts
+++ b/src/lib/api/articles.test.ts
@@ -1,35 +1,32 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-vi.mock('./fetch', () => ({
-	apiFetch: vi.fn()
-}));
-
-import { apiFetch } from './fetch';
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '$lib/mocks/server';
 import { searchArticles } from './articles';
 
-const mockApiFetch = vi.mocked(apiFetch);
+vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_API_BASE_URL: '' } }));
+vi.mock('$lib/utils/analytics', () => ({ getDistinctId: vi.fn(), isInternalUser: vi.fn() }));
 
-function makeResponse(items = []) {
-	return new Response(
-		JSON.stringify({ items, total: 0, page: 1, pageSize: 5, pages: 0 })
-	) as Response;
+function captureArticlesRequest() {
+	let params: URLSearchParams;
+	server.use(
+		http.get('*/api/v1/articles', ({ request }) => {
+			params = new URL(request.url).searchParams;
+			return HttpResponse.json({ items: [], total: 0, page: 1, pageSize: 5, pages: 0 });
+		})
+	);
+	return () => params;
 }
 
 describe('searchArticles', () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		mockApiFetch.mockResolvedValue(makeResponse());
-	});
-
 	it('should sort by published_date desc and limit to 5 when called with no options', async () => {
 		// Given: no options provided
+		const getParams = captureArticlesRequest();
 
 		// When: fetching articles
 		await searchArticles();
 
 		// Then: should request sort=published_date, order=desc, page_size=5, page=1, no query
-		const [url] = mockApiFetch.mock.calls[0];
-		const params = new URL(url as string, 'http://localhost').searchParams;
+		const params = getParams();
 		expect(params.get('sort')).toBe('published_date');
 		expect(params.get('order')).toBe('desc');
 		expect(params.get('page_size')).toBe('5');
@@ -39,13 +36,13 @@ describe('searchArticles', () => {
 
 	it('should include the query param and sort by date desc when searching by query', async () => {
 		// Given: a search query
+		const getParams = captureArticlesRequest();
 
 		// When: fetching articles with a query
 		await searchArticles({ query: 'CMU' });
 
 		// Then: should include q, sort=published_date, order=desc, page_size=5, page=1
-		const [url] = mockApiFetch.mock.calls[0];
-		const params = new URL(url as string, 'http://localhost').searchParams;
+		const params = getParams();
 		expect(params.get('q')).toBe('CMU');
 		expect(params.get('sort')).toBe('published_date');
 		expect(params.get('order')).toBe('desc');
@@ -55,25 +52,23 @@ describe('searchArticles', () => {
 
 	it('should pass the page param when specified', async () => {
 		// Given: page 2 is requested
+		const getParams = captureArticlesRequest();
 
 		// When: fetching articles with page=2
 		await searchArticles({ query: 'CMU', page: 2 });
 
 		// Then: should include page=2 in the request
-		const [url] = mockApiFetch.mock.calls[0];
-		const params = new URL(url as string, 'http://localhost').searchParams;
-		expect(params.get('page')).toBe('2');
+		expect(getParams().get('page')).toBe('2');
 	});
 
 	it('should encode special characters in the query param', async () => {
 		// Given: a query with special characters
+		const getParams = captureArticlesRequest();
 
 		// When: fetching articles
 		await searchArticles({ query: 'John & Jane' });
 
 		// Then: should URL-encode the query
-		const [url] = mockApiFetch.mock.calls[0];
-		const params = new URL(url as string, 'http://localhost').searchParams;
-		expect(params.get('q')).toBe('John & Jane');
+		expect(getParams().get('q')).toBe('John & Jane');
 	});
 });

--- a/src/lib/api/entities.test.ts
+++ b/src/lib/api/entities.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '$lib/mocks/server';
+import { fetchTopEntities } from './entities';
+
+vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_API_BASE_URL: '' } }));
+vi.mock('$lib/utils/analytics', () => ({ getDistinctId: vi.fn(), isInternalUser: vi.fn() }));
+
+function captureEntitiesRequest() {
+	let params: URLSearchParams;
+	server.use(
+		http.get('*/api/v1/entities', ({ request }) => {
+			params = new URL(request.url).searchParams;
+			return HttpResponse.json({ items: [], total: 0, page: 1, pageSize: 8, pages: 0 });
+		})
+	);
+	return () => params;
+}
+
+describe('fetchTopEntities', () => {
+	it('should default to most_found sort with page_size=8', async () => {
+		// Given: no sort specified
+		const getParams = captureEntitiesRequest();
+
+		// When: fetching top entities
+		await fetchTopEntities();
+
+		// Then: should request sort=most_found and page_size=8
+		expect(getParams().get('sort')).toBe('most_found');
+		expect(getParams().get('page_size')).toBe('8');
+	});
+
+	it('should use the provided sort order', async () => {
+		// Given: latest sort requested
+		const getParams = captureEntitiesRequest();
+
+		// When: fetching with sort=latest
+		await fetchTopEntities('latest');
+
+		// Then: should pass sort=latest
+		expect(getParams().get('sort')).toBe('latest');
+	});
+
+	it('should return the items array from the response', async () => {
+		// Given: the API returns entities (handled by the default MSW handler)
+
+		// When: fetching top entities
+		const result = await fetchTopEntities('most_found');
+
+		// Then: should return only the items array, sorted by article count descending
+		expect(Array.isArray(result)).toBe(true);
+		expect(result.length).toBeGreaterThan(0);
+		expect(result[0]).toHaveProperty('name');
+		expect(result[0]).toHaveProperty('articleCount');
+		for (let i = 1; i < result.length; i++) {
+			expect(result[i - 1].articleCount).toBeGreaterThanOrEqual(result[i].articleCount);
+		}
+	});
+
+	it('should return an empty array when the response is not ok', async () => {
+		// Given: the API returns a 500
+		server.use(http.get('*/api/v1/entities', () => new HttpResponse(null, { status: 500 })));
+
+		// When: fetching top entities
+		const result = await fetchTopEntities();
+
+		// Then: should return an empty array
+		expect(result).toEqual([]);
+	});
+});

--- a/src/lib/api/metrics.test.ts
+++ b/src/lib/api/metrics.test.ts
@@ -1,36 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-vi.mock('./fetch', () => ({
-	apiFetch: vi.fn()
-}));
-
-import { apiFetch } from './fetch';
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '$lib/mocks/server';
 import { fetchMetrics } from './metrics';
 
-const mockApiFetch = vi.mocked(apiFetch);
+vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_API_BASE_URL: '' } }));
+vi.mock('$lib/utils/analytics', () => ({ getDistinctId: vi.fn(), isInternalUser: vi.fn() }));
 
 describe('fetchMetrics', () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-	});
-
 	it('should request /api/v1/metrics and return the parsed response', async () => {
-		// Given: the API returns metrics
-		mockApiFetch.mockResolvedValue(
-			new Response(JSON.stringify({ articleCount: 12345, entityCount: 1200 }))
-		);
+		// Given: the API returns metrics (handled by the default MSW handler)
 
 		// When: fetching metrics
 		const result = await fetchMetrics();
 
-		// Then: should call the metrics endpoint and return the parsed body
-		expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/metrics');
+		// Then: should return the parsed metrics body
 		expect(result).toEqual({ articleCount: 12345, entityCount: 1200 });
 	});
 
 	it('should return null when the response is not ok', async () => {
 		// Given: the API returns a 500
-		mockApiFetch.mockResolvedValue(new Response('error', { status: 500 }));
+		server.use(http.get('*/api/v1/metrics', () => new HttpResponse(null, { status: 500 })));
 
 		// When: fetching metrics
 		const result = await fetchMetrics();

--- a/src/lib/api/metrics.test.ts
+++ b/src/lib/api/metrics.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./fetch', () => ({
+	apiFetch: vi.fn()
+}));
+
+import { apiFetch } from './fetch';
+import { fetchMetrics } from './metrics';
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+describe('fetchMetrics', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should request /api/v1/metrics and return the parsed response', async () => {
+		// Given: the API returns metrics
+		mockApiFetch.mockResolvedValue(
+			new Response(JSON.stringify({ articleCount: 12345, entityCount: 1200 }))
+		);
+
+		// When: fetching metrics
+		const result = await fetchMetrics();
+
+		// Then: should call the metrics endpoint and return the parsed body
+		expect(mockApiFetch).toHaveBeenCalledWith('/api/v1/metrics');
+		expect(result).toEqual({ articleCount: 12345, entityCount: 1200 });
+	});
+
+	it('should return null when the response is not ok', async () => {
+		// Given: the API returns a 500
+		mockApiFetch.mockResolvedValue(new Response('error', { status: 500 }));
+
+		// When: fetching metrics
+		const result = await fetchMetrics();
+
+		// Then: should return null
+		expect(result).toBeNull();
+	});
+});

--- a/src/lib/api/metrics.ts
+++ b/src/lib/api/metrics.ts
@@ -1,0 +1,10 @@
+import type { MetricsResponse } from './types';
+import { apiFetch } from './fetch';
+
+export async function fetchMetrics(): Promise<MetricsResponse | null> {
+	const response = await apiFetch('/api/v1/metrics');
+	if (!response.ok) {
+		return null;
+	}
+	return response.json();
+}

--- a/src/lib/api/openapi.yaml
+++ b/src/lib/api/openapi.yaml
@@ -215,6 +215,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /metrics:
+    get:
+      summary: Get site-wide metrics
+      description: |
+        Returns aggregate counts used by the frontend hero section:
+        - `articleCount`: total number of articles stored
+        - `entityCount`: total number of distinct entities that appear in at least one article
+          (orphaned entities with no article links are excluded)
+
+        Results are cached server-side (TTL 300s) and may be slightly stale.
+      operationId: getMetrics
+      tags:
+        - Metrics
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsResponse'
+
+        '500':
+          description: Database/server errors
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /entities:
     get:
       summary: List entities
@@ -482,6 +510,23 @@ components:
           format: date-time
           description: Most recent article publication date featuring this entity (scoped by time window if since is provided)
           example: '2024-02-14T09:15:00Z'
+
+    # ── Metrics ─────────────────────────────────────────────────────
+
+    MetricsResponse:
+      type: object
+      required:
+        - articleCount
+        - entityCount
+      properties:
+        articleCount:
+          type: integer
+          description: Total number of articles stored
+          example: 12345
+        entityCount:
+          type: integer
+          description: Total number of distinct entities appearing in at least one article
+          example: 1200
 
     # ── Shared ──────────────────────────────────────────────────────
 

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -62,3 +62,8 @@ export interface EntityListResponse {
 	pageSize: number;
 	pages: number;
 }
+
+export interface MetricsResponse {
+	articleCount: number;
+	entityCount: number;
+}

--- a/src/lib/components/features/home/HeroSection.svelte
+++ b/src/lib/components/features/home/HeroSection.svelte
@@ -1,76 +1,107 @@
 <script lang="ts">
-	// Hero section for JAccountable landing page
+	import { Newspaper, Tags } from 'lucide-svelte';
+	import type { MetricsResponse } from '$lib/api/types';
+
+	let { metrics }: { metrics: MetricsResponse | null } = $props();
+
+	const COUNT_UP_DURATION_MS = 1200;
+
+	let displayedArticles = $state(0);
+	let displayedTopics = $state(0);
+
+	function countUp(target: number, set: (n: number) => void): void {
+		const start = performance.now();
+		function tick(now: number) {
+			const t = Math.min(1, (now - start) / COUNT_UP_DURATION_MS);
+			// easeOutQuart for a snappy settle
+			const eased = 1 - Math.pow(1 - t, 4);
+			set(Math.round(target * eased));
+			if (t < 1) requestAnimationFrame(tick);
+		}
+		requestAnimationFrame(tick);
+	}
+
+	$effect(() => {
+		if (!metrics) return;
+		countUp(metrics.articleCount, (n) => (displayedArticles = n));
+		countUp(metrics.entityCount, (n) => (displayedTopics = n));
+	});
 </script>
 
 <section
 	class="relative h-screen w-full overflow-hidden flex items-center justify-center bg-linear-to-b from-background to-neutral-300"
 >
 	<div class="relative z-10 max-w-5xl mx-auto px-6 text-center">
-		<!-- Main headline -->
 		<h1
-			class="text-5xl md:text-7xl lg:text-8xl font-black leading-[1.1] mb-12 tracking-tight text-primary"
+			class="text-5xl md:text-7xl lg:text-8xl font-black leading-[1.1] mb-8 tracking-tight text-primary"
 		>
-			<span class="block opacity-0 animate-line-1"
-				>Every <span class="gradient-text">Scandal.</span></span
-			>
-			<span class="block opacity-0 animate-line-2"
-				>Every <span class="gradient-text">Investigation.</span></span
-			>
-			<span class="block opacity-0 animate-line-3"
-				>One <span class="gradient-text">Place.</span></span
-			>
+			<span class="block">Every <span class="gradient-text">Scandal.</span></span>
+			<span class="block">Every <span class="gradient-text">Investigation.</span></span>
+			<span class="block">One <span class="gradient-text">Place.</span></span>
 		</h1>
 
-		<!-- Animated vertical line -->
-		<div class="flex justify-center opacity-0 animate-fade-in-delayed">
-			<div
-				class="w-1 h-24 rounded-full bg-linear-to-b from-accent to-transparent animate-pulse"
-			></div>
-		</div>
+		<p
+			class="text-lg md:text-xl text-primary/80 max-w-2xl mx-auto mb-12 leading-relaxed font-light"
+		>
+			Track how Jamaican news outlets cover
+			<strong class="font-semibold text-primary">scandals</strong>,
+			<strong class="font-semibold text-primary">investigations</strong>, and the
+			<strong class="font-semibold text-primary">people</strong> behind them — all in one searchable place.
+		</p>
+
+		{#if metrics}
+			<div class="flex flex-col sm:flex-row justify-center items-center gap-8 sm:gap-16">
+				<div class="flex items-center gap-4" data-testid="metric-articles">
+					<Newspaper class="w-10 h-10 md:w-12 md:h-12 text-accent" />
+					<div class="text-left">
+						<div class="text-4xl md:text-5xl font-bold text-primary leading-none tabular-nums">
+							{displayedArticles.toLocaleString()}
+						</div>
+						<div class="text-sm md:text-base uppercase tracking-wider text-primary/70 mt-1">
+							Articles
+						</div>
+					</div>
+				</div>
+				<div class="flex items-center gap-4" data-testid="metric-topics">
+					<Tags class="w-10 h-10 md:w-12 md:h-12 text-accent" />
+					<div class="text-left">
+						<div class="text-4xl md:text-5xl font-bold text-primary leading-none tabular-nums">
+							{displayedTopics.toLocaleString()}
+						</div>
+						<div class="text-sm md:text-base uppercase tracking-wider text-primary/70 mt-1">
+							Topics
+						</div>
+					</div>
+				</div>
+			</div>
+		{/if}
 	</div>
 </section>
 
 <style>
-	@keyframes fadeIn {
-		from {
-			opacity: 0;
-		}
-		to {
-			opacity: 1;
-		}
-	}
-
-	@keyframes slideUp {
-		from {
-			opacity: 0;
-			transform: translateY(40px);
-		}
-		to {
-			opacity: 1;
-			transform: translateY(0);
-		}
-	}
-
-	.animate-line-1 {
-		animation: slideUp 1s ease-out forwards 0.8s;
-	}
-
-	.animate-line-2 {
-		animation: slideUp 1s ease-out forwards 1.8s;
-	}
-
-	.animate-line-3 {
-		animation: slideUp 1s ease-out forwards 2.8s;
-	}
-
-	.animate-fade-in-delayed {
-		animation: fadeIn 1s ease-out forwards 4s;
-	}
-
 	.gradient-text {
-		background: linear-gradient(to right, var(--color-accent), var(--color-secondary));
+		background: linear-gradient(
+			90deg,
+			var(--color-accent) 0%,
+			var(--color-secondary) 50%,
+			var(--color-accent) 100%
+		);
+		background-size: 200% 100%;
+		background-position: 0% 0;
 		-webkit-background-clip: text;
 		background-clip: text;
 		color: transparent;
+		transition: background-position 0.8s ease;
+		cursor: default;
+	}
+
+	.gradient-text:hover {
+		background-position: 100% 0;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.gradient-text {
+			transition: none;
+		}
 	}
 </style>

--- a/src/lib/components/features/home/HeroSection.test.ts
+++ b/src/lib/components/features/home/HeroSection.test.ts
@@ -1,11 +1,11 @@
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
 import HeroSection from './HeroSection.svelte';
 
 describe('HeroSection', () => {
 	it('should display the main headline', () => {
-		// Given: the hero component renders
-		render(HeroSection);
+		// Given: the hero component renders with no metrics
+		render(HeroSection, { props: { metrics: null } });
 
 		// When: the page loads
 
@@ -17,7 +17,7 @@ describe('HeroSection', () => {
 
 	it('should display gradient text spans with gradient-text class', () => {
 		// Given: the hero component renders
-		render(HeroSection);
+		render(HeroSection, { props: { metrics: null } });
 
 		// When: the page loads
 
@@ -30,19 +30,50 @@ describe('HeroSection', () => {
 		});
 	});
 
-	it('should display each headline line with staggered animation classes', () => {
+	it('should display the description', () => {
 		// Given: the hero component renders
-		render(HeroSection);
+		render(HeroSection, { props: { metrics: null } });
 
 		// When: the page loads
 
-		// Then: should display each headline line with staggered animation classes
-		const heading = screen.getByRole('heading', { level: 1 });
-		const lineSpans = heading.querySelectorAll(':scope > span.block');
+		// Then: should display the description copy with key words bolded
+		expect(screen.getByText(/Track how Jamaican news outlets cover/i)).toBeInTheDocument();
+		['scandals', 'investigations', 'people'].forEach((word) => {
+			const node = screen.getByText(word);
+			expect(node.tagName).toBe('STRONG');
+		});
+	});
 
-		expect(lineSpans).toHaveLength(3);
-		expect(lineSpans[0]).toHaveClass('animate-line-1');
-		expect(lineSpans[1]).toHaveClass('animate-line-2');
-		expect(lineSpans[2]).toHaveClass('animate-line-3');
+	it('should display formatted metric counts and labels when metrics are provided', async () => {
+		// Given: the hero component renders with metrics
+		render(HeroSection, {
+			props: { metrics: { articleCount: 12345, entityCount: 1200 } }
+		});
+
+		// When: the page loads and the count-up animation finishes
+
+		// Then: should eventually show both stats with thousands separators and labels
+		const articles = screen.getByTestId('metric-articles');
+		const topics = screen.getByTestId('metric-topics');
+		expect(articles).toHaveTextContent('Articles');
+		expect(topics).toHaveTextContent('Topics');
+		await waitFor(
+			() => {
+				expect(articles).toHaveTextContent('12,345');
+				expect(topics).toHaveTextContent('1,200');
+			},
+			{ timeout: 3000 }
+		);
+	});
+
+	it('should not render the stats block when metrics are null', () => {
+		// Given: the hero component renders with no metrics
+		render(HeroSection, { props: { metrics: null } });
+
+		// When: the page loads
+
+		// Then: should not render either metric block
+		expect(screen.queryByTestId('metric-articles')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('metric-topics')).not.toBeInTheDocument();
 	});
 });

--- a/src/lib/mocks/fixtures/metrics.ts
+++ b/src/lib/mocks/fixtures/metrics.ts
@@ -1,0 +1,6 @@
+import type { MetricsResponse } from '$lib/api/types';
+
+export const mockMetrics: MetricsResponse = {
+	articleCount: 12345,
+	entityCount: 1200
+};

--- a/src/lib/mocks/handlers/index.ts
+++ b/src/lib/mocks/handlers/index.ts
@@ -1,4 +1,5 @@
 import { articleHandlers } from './articles';
 import { entityHandlers } from './entities';
+import { metricsHandlers } from './metrics';
 
-export const handlers = [...articleHandlers, ...entityHandlers];
+export const handlers = [...articleHandlers, ...entityHandlers, ...metricsHandlers];

--- a/src/lib/mocks/handlers/metrics.ts
+++ b/src/lib/mocks/handlers/metrics.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse, delay } from 'msw';
+import type { MetricsResponse } from '$lib/api/types';
+import { mockMetrics } from '../fixtures/metrics';
+
+export const metricsHandlers = [
+	http.get<never, never, MetricsResponse>('*/api/v1/metrics', async () => {
+		if (!import.meta.env.TEST) {
+			await delay(500);
+		}
+		return HttpResponse.json(mockMetrics);
+	})
+];

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad } from './$types';
-import type { Article, EntitySummary } from '$lib/api/types';
+import type { Article, EntitySummary, MetricsResponse } from '$lib/api/types';
 import { env as privateEnv } from '$env/dynamic/private';
 import { env as publicEnv } from '$env/dynamic/public';
 
@@ -12,9 +12,10 @@ export const load: PageServerLoad = async ({ fetch }) => {
 	// both use the same public host.
 	const base = privateEnv.INTERNAL_API_BASE_URL ?? publicEnv.PUBLIC_API_BASE_URL ?? '';
 
-	const [articlesRes, entitiesRes] = await Promise.all([
+	const [articlesRes, entitiesRes, metricsRes] = await Promise.all([
 		fetch(`${base}/api/v1/articles?sort=published_date&order=desc&page_size=5&page=1`),
-		fetch(`${base}/api/v1/entities?sort=most_found&page_size=8`)
+		fetch(`${base}/api/v1/entities?sort=most_found&page_size=8`),
+		fetch(`${base}/api/v1/metrics`)
 	]);
 
 	const articlesData = articlesRes.ok ? await articlesRes.json() : null;
@@ -26,5 +27,7 @@ export const load: PageServerLoad = async ({ fetch }) => {
 	const entitiesData = entitiesRes.ok ? await entitiesRes.json() : null;
 	const topics: EntitySummary[] = entitiesData?.items ?? [];
 
-	return { latestArticles, latestPage, latestTotalPages, latestTotal, topics };
+	const metrics: MetricsResponse | null = metricsRes.ok ? await metricsRes.json() : null;
+
+	return { latestArticles, latestPage, latestTotalPages, latestTotal, topics, metrics };
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,7 +18,8 @@
 		latestPage,
 		latestTotalPages,
 		latestTotal,
-		topics: initialTopics
+		topics: initialTopics,
+		metrics
 	} = untrack(() => data);
 
 	let searchState: {
@@ -142,7 +143,7 @@
 </script>
 
 <main>
-	<HeroSection />
+	<HeroSection {metrics} />
 	<ChallengeSection />
 	<SearchSection
 		{displayedArticles}


### PR DESCRIPTION
Replace the static animated headline with a metrics-driven hero: fetch
/api/v1/metrics server-side, render article and topic counts with a
count-up animation and tabular numerals, add a description with
emphasised key words, and add a hover shimmer (green to yellow,
reversing on hover) on the gradient words. Includes MSW handler/fixture
and tests.

closes #138 