### PR TITLE
feat(home): move SearchSection directly below Hero

### DIFF
--- a/src/lib/components/features/Header.svelte
+++ b/src/lib/components/features/Header.svelte
@@ -54,20 +54,20 @@
 			<ul class="flex items-center gap-8">
 				<li>
 					<a
-						href="/#why"
-						onclick={(e) => scrollToSection(e, 'why')}
-						class="text-sm font-semibold tracking-[0.15em] uppercase text-primary hover:text-accent transition-colors"
-					>
-						WHY
-					</a>
-				</li>
-				<li>
-					<a
 						href="/#search"
 						onclick={(e) => scrollToSection(e, 'search')}
 						class="text-sm font-semibold tracking-[0.15em] uppercase text-primary hover:text-accent transition-colors"
 					>
 						SEARCH
+					</a>
+				</li>
+				<li>
+					<a
+						href="/#why"
+						onclick={(e) => scrollToSection(e, 'why')}
+						class="text-sm font-semibold tracking-[0.15em] uppercase text-primary hover:text-accent transition-colors"
+					>
+						WHY
 					</a>
 				</li>
 				<li>
@@ -120,20 +120,20 @@
 			<ul class="flex flex-col gap-4">
 				<li>
 					<a
-						href="/#why"
-						onclick={(e) => scrollToSection(e, 'why')}
-						class="block text-sm font-semibold tracking-[0.15em] uppercase text-primary hover:text-accent transition-colors"
-					>
-						WHY
-					</a>
-				</li>
-				<li>
-					<a
 						href="/#search"
 						onclick={(e) => scrollToSection(e, 'search')}
 						class="block text-sm font-semibold tracking-[0.15em] uppercase text-primary hover:text-accent transition-colors"
 					>
 						SEARCH
+					</a>
+				</li>
+				<li>
+					<a
+						href="/#why"
+						onclick={(e) => scrollToSection(e, 'why')}
+						class="block text-sm font-semibold tracking-[0.15em] uppercase text-primary hover:text-accent transition-colors"
+					>
+						WHY
 					</a>
 				</li>
 				<li>

--- a/src/lib/components/features/home/FeaturesSection.svelte
+++ b/src/lib/components/features/home/FeaturesSection.svelte
@@ -2,7 +2,7 @@
 	import { Newspaper, BrainCog, UserSearch } from 'lucide-svelte';
 </script>
 
-<section id="how-it-works" class="bg-surface py-24 relative overflow-hidden">
+<section id="how-it-works" class="bg-neutral-100 py-24 relative overflow-hidden">
 	<!-- Decorative blur element -->
 	<div
 		class="absolute bottom-0 left-0 w-96 h-96 bg-accent/5 rounded-full blur-3xl -ml-48 -mb-48"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -144,7 +144,6 @@
 
 <main>
 	<HeroSection {metrics} />
-	<ChallengeSection />
 	<SearchSection
 		{displayedArticles}
 		{hasMoreResults}
@@ -163,6 +162,7 @@
 		onSortChange={handleSortChange}
 		onLoadMore={handleLoadMore}
 	/>
+	<ChallengeSection />
 	<FeaturesSection />
 	<FAQSection />
 	<ShareSection />


### PR DESCRIPTION
Promotes search to the primary above-the-fold action to drive engagement. Nav order updated to match (SEARCH before WHY); FeaturesSection background switched to bg-neutral-100 so it no longer blends into ChallengeSection now that they're adjacent.