### PR TITLE
feat(article): make entity pills navigate to home search

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,11 @@ export default defineConfig(
 		// Hash fragment routes (e.g. /#why) are not in SvelteKit's Route type, so resolve() cannot
 		// wrap them directly. We use `${resolve('/')}#section` instead, which is correct but the
 		// rule can't detect it. The TypeScript check prevents misuse elsewhere.
-		files: ['src/lib/components/features/Header.svelte'],
+		files: [
+			'src/lib/components/features/Header.svelte',
+			'src/lib/components/features/article/ArticleDetailView.svelte',
+			'src/routes/+page.svelte'
+		],
 		rules: {
 			'svelte/no-navigation-without-resolve': 'off'
 		}

--- a/src/lib/components/features/article/ArticleDetailView.svelte
+++ b/src/lib/components/features/article/ArticleDetailView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { resolve } from '$app/paths';
+	import { goto } from '$app/navigation';
 	import type { Article } from '$lib/api/types';
 	import ArticleSourceHeader from '../ArticleSourceHeader.svelte';
 	import AnalysisAlert from '../AnalysisAlert.svelte';
@@ -8,6 +9,10 @@
 
 	let { article, relatedArticles = [] }: { article: Article; relatedArticles?: Article[] } =
 		$props();
+
+	function handleTopicClick(entity: string) {
+		goto(resolve('/') + '?topic=' + encodeURIComponent(entity) + '#search');
+	}
 
 	const paragraphs = $derived(
 		article.fullText
@@ -44,11 +49,12 @@
 					<h2 class="mb-2 text-sm font-semibold text-accent">Mentioned</h2>
 					<div class="flex flex-wrap gap-2">
 						{#each article.entities as entity (entity)}
-							<span
-								class="rounded-md border border-border bg-muted px-2 py-1 text-xs text-muted-foreground"
+							<button
+								class="rounded-md border border-border bg-muted px-2 py-1 text-xs text-muted-foreground transition hover:bg-sidebar-accent hover:text-sidebar-accent-foreground cursor-pointer"
+								onclick={() => handleTopicClick(entity)}
 							>
 								{entity}
-							</span>
+							</button>
 						{/each}
 					</div>
 				</div>

--- a/src/lib/components/features/article/ArticleDetailView.test.ts
+++ b/src/lib/components/features/article/ArticleDetailView.test.ts
@@ -1,6 +1,11 @@
-import { render, screen } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
 import ArticleDetailView from './ArticleDetailView.svelte';
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
+import { goto } from '$app/navigation';
 import type { Article } from '$lib/api/types';
 
 const gleanerArticle: Article = {
@@ -267,5 +272,29 @@ describe('ArticleDetailView', () => {
 
 		// Then: should display the empty state message
 		expect(screen.getByTestId('no-related-articles')).toBeInTheDocument();
+	});
+
+	it('should render entity pills as clickable buttons', () => {
+		// Given: the component renders with an article that has entities
+		render(ArticleDetailView, { props: { article: gleanerArticle } });
+
+		// When: the page loads
+
+		// Then: each entity should be a button
+		gleanerArticle.entities.forEach((entity) => {
+			expect(screen.getByRole('button', { name: entity })).toBeInTheDocument();
+		});
+	});
+
+	it('should navigate to home with topic query param when entity pill is clicked', () => {
+		// Given: the component renders with an article
+		render(ArticleDetailView, { props: { article: gleanerArticle } });
+
+		// When: user clicks the first entity pill
+		const firstEntity = gleanerArticle.entities[0];
+		fireEvent.click(screen.getByRole('button', { name: firstEntity }));
+
+		// Then: should navigate to /?topic={entity}#search
+		expect(goto).toHaveBeenCalledWith(`/?topic=${encodeURIComponent(firstEntity)}#search`);
 	});
 });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,11 +3,14 @@
 	import SearchSection from '$lib/components/features/home/SearchSection.svelte';
 	import FeaturesSection from '$lib/components/features/home/FeaturesSection.svelte';
 	import ShareSection from '$lib/components/features/home/ShareSection.svelte';
-	import { untrack } from 'svelte';
+	import { untrack, onMount } from 'svelte';
 	import type { Article, EntitySummary, EntitySortOrder } from '$lib/api/types';
 	import type { PageData } from './$types';
 	import { searchArticles } from '$lib/api/articles';
 	import { fetchTopEntities } from '$lib/api/entities';
+	import { replaceState } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { page } from '$app/state';
 
 	let { data }: { data: PageData } = $props();
 
@@ -53,6 +56,14 @@
 		searchState.hasSearched ? searchState.query : (searchState.selectedTopic ?? 'Latest Stories')
 	);
 	const noResults: boolean = $derived(searchState.hasSearched && searchState.results.length === 0);
+
+	onMount(() => {
+		const topic = page.url.searchParams.get('topic');
+		if (topic) {
+			handleTopicClick(topic);
+			replaceState(resolve('/') + '#search', {});
+		}
+	});
 
 	async function handleSearch(query: string): Promise<void> {
 		if (!query.trim()) {


### PR DESCRIPTION
Clicking a topic pill on the article detail page now navigates to /?topic=EntityName#search. The home page reads this param on mount, triggers the search via handleTopicClick, then cleans the URL with replaceState.

Issues:
closes #130