### PR TITLE
feat(analytics): forward PostHog session ID to backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,22 @@ Custom event tracking uses PostHog via `$lib/utils/analytics.ts`.
 ### Tracking Utility
 
 - **`trackEvent(eventName, properties?)`** — wraps `posthog.capture()`, automatically attaches `environment` (from `import.meta.env.MODE`) and `is_internal` (from `isInternalUser()`) to every event. Guarded with `browser` check for SSR safety.
-- **`isInternalUser()`** — dedicated function for internal user detection, currently checks `window.location.hostname.includes('localhost')`. Extracted for future extensibility (e.g., email-based checks).
+- **`isInternalUser()`** — browser-side internal user detection. Delegates to the shared `isInternalHost(hostname)` predicate (also used server-side) which currently matches `localhost` and `staging.jaccountable.org`.
+
+### Backend Event Attribution
+
+The backend (`posthog-python`) also captures events for some flows (e.g. `article:detail_view`). To stitch those events into the same PostHog session/person as the browser, the frontend forwards three headers on every backend request:
+
+- `X-PostHog-Distinct-Id`
+- `X-PostHog-Session-Id`
+- `X-Internal-Request`
+
+There are two code paths because session/distinct IDs live in different places client-side vs server-side:
+
+- **Client-side fetches** (`+page.svelte` → `$lib/api/*` → `apiFetch`): `src/lib/api/fetch.ts` reads from `posthog-js` directly via `getDistinctId()` / `getSessionId()` in `$lib/utils/analytics.ts`.
+- **Server-side loads** (`+page.server.ts` using SvelteKit's `fetch`): `src/lib/server/analytics.ts` exports `buildAnalyticHeaders(cookies, url)` which parses the `ph_<PUBLIC_POSTHOG_KEY>_posthog` cookie (PostHog stores `distinct_id` and `$sesid[1]` there) and derives `is_internal` from the request hostname. Lives under `$lib/server/` so SvelteKit blocks accidental client imports.
+
+When adding a new `+page.server.ts` (or any server-side backend fetch), call `buildAnalyticHeaders(cookies, url)` once and pass the resulting `headers` to every `fetch` call. Header casing matches `X-PostHog-Distinct-Id` style (not the all-caps form in the PostHog docs) — the backend reads them with that casing.
 
 ### Event Naming Conventions
 

--- a/src/lib/api/articles.test.ts
+++ b/src/lib/api/articles.test.ts
@@ -4,7 +4,11 @@ import { server } from '$lib/mocks/server';
 import { searchArticles } from './articles';
 
 vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_API_BASE_URL: '' } }));
-vi.mock('$lib/utils/analytics', () => ({ getDistinctId: vi.fn(), isInternalUser: vi.fn() }));
+vi.mock('$lib/utils/analytics', () => ({
+	getDistinctId: vi.fn(),
+	getSessionId: vi.fn(),
+	isInternalUser: vi.fn()
+}));
 
 function captureArticlesRequest() {
 	let params: URLSearchParams;

--- a/src/lib/api/entities.test.ts
+++ b/src/lib/api/entities.test.ts
@@ -4,7 +4,11 @@ import { server } from '$lib/mocks/server';
 import { fetchTopEntities } from './entities';
 
 vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_API_BASE_URL: '' } }));
-vi.mock('$lib/utils/analytics', () => ({ getDistinctId: vi.fn(), isInternalUser: vi.fn() }));
+vi.mock('$lib/utils/analytics', () => ({
+	getDistinctId: vi.fn(),
+	getSessionId: vi.fn(),
+	isInternalUser: vi.fn()
+}));
 
 function captureEntitiesRequest() {
 	let params: URLSearchParams;

--- a/src/lib/api/fetch.test.ts
+++ b/src/lib/api/fetch.test.ts
@@ -6,6 +6,7 @@ vi.mock('$env/dynamic/public', () => ({
 
 vi.mock('$lib/utils/analytics', () => ({
 	getDistinctId: vi.fn(),
+	getSessionId: vi.fn(),
 	isInternalUser: vi.fn()
 }));
 
@@ -13,10 +14,11 @@ vi.mock('$app/environment', () => ({
 	browser: true
 }));
 
-import { getDistinctId, isInternalUser } from '$lib/utils/analytics';
+import { getDistinctId, getSessionId, isInternalUser } from '$lib/utils/analytics';
 import { apiFetch } from './fetch';
 
 const mockGetDistinctId = vi.mocked(getDistinctId);
+const mockGetSessionId = vi.mocked(getSessionId);
 const mockIsInternalUser = vi.mocked(isInternalUser);
 
 describe('apiFetch', () => {
@@ -51,6 +53,34 @@ describe('apiFetch', () => {
 		const [, init] = vi.mocked(fetch).mock.calls[0];
 		const headers = new Headers(init?.headers);
 		expect(headers.get('X-PostHog-Distinct-Id')).toBeNull();
+	});
+
+	it('should inject X-PostHog-Session-Id header when a session ID is available', async () => {
+		// Given: PostHog has an active session
+		mockGetSessionId.mockReturnValue('session-xyz');
+		mockIsInternalUser.mockReturnValue(false);
+
+		// When: making an API request
+		await apiFetch('/api/v1/articles');
+
+		// Then: should send the session ID header
+		const [, init] = vi.mocked(fetch).mock.calls[0];
+		const headers = new Headers(init?.headers);
+		expect(headers.get('X-PostHog-Session-Id')).toBe('session-xyz');
+	});
+
+	it('should not inject X-PostHog-Session-Id header when session ID is unavailable', async () => {
+		// Given: PostHog has no active session (e.g. SSR or recording disabled)
+		mockGetSessionId.mockReturnValue(undefined);
+		mockIsInternalUser.mockReturnValue(false);
+
+		// When: making an API request
+		await apiFetch('/api/v1/articles');
+
+		// Then: should not include the header
+		const [, init] = vi.mocked(fetch).mock.calls[0];
+		const headers = new Headers(init?.headers);
+		expect(headers.get('X-PostHog-Session-Id')).toBeNull();
 	});
 
 	it('should inject X-Internal-Request header when user is internal', async () => {

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -1,13 +1,20 @@
 import { env } from '$env/dynamic/public';
 
 const { PUBLIC_API_BASE_URL } = env;
-import { getDistinctId, isInternalUser } from '$lib/utils/analytics';
+import { getDistinctId, getSessionId, isInternalUser } from '$lib/utils/analytics';
+
+function addAnalyticHeaders(headers: Headers): Headers {
+	const next = new Headers(headers);
+	const distinctId = getDistinctId();
+	if (distinctId) next.set('X-PostHog-Distinct-Id', distinctId);
+	const sessionId = getSessionId();
+	if (sessionId) next.set('X-PostHog-Session-Id', sessionId);
+	if (isInternalUser()) next.set('X-Internal-Request', 'true');
+	return next;
+}
 
 export function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-	const headers = new Headers(init?.headers);
-	const distinctId = getDistinctId();
-	if (distinctId) headers.set('X-PostHog-Distinct-Id', distinctId);
-	if (isInternalUser()) headers.set('X-Internal-Request', 'true');
+	const headers = addAnalyticHeaders(new Headers(init?.headers));
 
 	const url =
 		typeof input === 'string' && PUBLIC_API_BASE_URL ? `${PUBLIC_API_BASE_URL}${input}` : input;

--- a/src/lib/api/metrics.test.ts
+++ b/src/lib/api/metrics.test.ts
@@ -4,7 +4,11 @@ import { server } from '$lib/mocks/server';
 import { fetchMetrics } from './metrics';
 
 vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_API_BASE_URL: '' } }));
-vi.mock('$lib/utils/analytics', () => ({ getDistinctId: vi.fn(), isInternalUser: vi.fn() }));
+vi.mock('$lib/utils/analytics', () => ({
+	getDistinctId: vi.fn(),
+	getSessionId: vi.fn(),
+	isInternalUser: vi.fn()
+}));
 
 describe('fetchMetrics', () => {
 	it('should request /api/v1/metrics and return the parsed response', async () => {

--- a/src/lib/server/analytics.test.ts
+++ b/src/lib/server/analytics.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Cookies } from '@sveltejs/kit';
+
+vi.mock('$env/dynamic/public', () => ({
+	env: { PUBLIC_POSTHOG_KEY: 'phc_test_key' }
+}));
+
+import { buildAnalyticHeaders } from './analytics';
+
+function makeCookies(cookieValue?: string): Cookies {
+	return {
+		get: vi.fn().mockReturnValue(cookieValue)
+	} as unknown as Cookies;
+}
+
+const validCookie = JSON.stringify({
+	distinct_id: 'distinct-abc',
+	$sesid: [1779656806803, 'session-xyz', 1779652372426]
+});
+
+describe('buildAnalyticHeaders', () => {
+	it('should set distinct ID and session ID headers from the PostHog cookie', () => {
+		// Given: a PostHog cookie with both IDs
+		const cookies = makeCookies(validCookie);
+
+		// When: building analytic headers
+		const headers = buildAnalyticHeaders(cookies, new URL('https://jaccountable.org/'));
+
+		// Then: should include both header values and read from the namespaced cookie
+		expect(headers.get('X-PostHog-Distinct-Id')).toBe('distinct-abc');
+		expect(headers.get('X-PostHog-Session-Id')).toBe('session-xyz');
+		expect(cookies.get).toHaveBeenCalledWith('ph_phc_test_key_posthog');
+	});
+
+	it('should set X-Internal-Request when hostname is localhost', () => {
+		// Given: a request from localhost
+		const cookies = makeCookies(validCookie);
+
+		// When: building analytic headers
+		const headers = buildAnalyticHeaders(cookies, new URL('http://localhost:5173/'));
+
+		// Then: should flag the request as internal
+		expect(headers.get('X-Internal-Request')).toBe('true');
+	});
+
+	it('should set X-Internal-Request when hostname is staging.jaccountable.org', () => {
+		// Given: a request from the staging domain
+		const cookies = makeCookies(validCookie);
+
+		// When: building analytic headers
+		const headers = buildAnalyticHeaders(cookies, new URL('https://staging.jaccountable.org/'));
+
+		// Then: should flag the request as internal
+		expect(headers.get('X-Internal-Request')).toBe('true');
+	});
+
+	it('should not set X-Internal-Request for production hostname', () => {
+		// Given: a request from the production domain
+		const cookies = makeCookies(validCookie);
+
+		// When: building analytic headers
+		const headers = buildAnalyticHeaders(cookies, new URL('https://jaccountable.org/'));
+
+		// Then: should not flag the request as internal
+		expect(headers.get('X-Internal-Request')).toBeNull();
+	});
+
+	it('should omit PostHog headers when the cookie is absent', () => {
+		// Given: no PostHog cookie on the request (e.g. first visit)
+		const cookies = makeCookies(undefined);
+
+		// When: building analytic headers
+		const headers = buildAnalyticHeaders(cookies, new URL('https://jaccountable.org/'));
+
+		// Then: should not include any PostHog headers
+		expect(headers.get('X-PostHog-Distinct-Id')).toBeNull();
+		expect(headers.get('X-PostHog-Session-Id')).toBeNull();
+	});
+
+	it('should omit PostHog headers when the cookie is malformed JSON', () => {
+		// Given: a PostHog cookie that cannot be parsed
+		const cookies = makeCookies('not-json-{');
+
+		// When: building analytic headers
+		const headers = buildAnalyticHeaders(cookies, new URL('https://jaccountable.org/'));
+
+		// Then: should silently omit the headers rather than throwing
+		expect(headers.get('X-PostHog-Distinct-Id')).toBeNull();
+		expect(headers.get('X-PostHog-Session-Id')).toBeNull();
+	});
+
+	it('should omit session ID when the cookie has distinct_id but no $sesid', () => {
+		// Given: a PostHog cookie missing the session entry
+		const cookies = makeCookies(JSON.stringify({ distinct_id: 'distinct-abc' }));
+
+		// When: building analytic headers
+		const headers = buildAnalyticHeaders(cookies, new URL('https://jaccountable.org/'));
+
+		// Then: should set the distinct ID but not the session ID
+		expect(headers.get('X-PostHog-Distinct-Id')).toBe('distinct-abc');
+		expect(headers.get('X-PostHog-Session-Id')).toBeNull();
+	});
+});

--- a/src/lib/server/analytics.ts
+++ b/src/lib/server/analytics.ts
@@ -1,0 +1,31 @@
+import type { Cookies } from '@sveltejs/kit';
+import { env as publicEnv } from '$env/dynamic/public';
+import { isInternalHost } from '$lib/utils/analytics';
+
+const { PUBLIC_POSTHOG_KEY } = publicEnv;
+
+type PostHogCookie = {
+	distinct_id?: string;
+	$sesid?: [number, string, number];
+};
+
+function readPostHogCookie(cookies: Cookies): PostHogCookie | null {
+	if (!PUBLIC_POSTHOG_KEY) return null;
+	const raw = cookies.get(`ph_${PUBLIC_POSTHOG_KEY}_posthog`);
+	if (!raw) return null;
+	try {
+		return JSON.parse(raw) as PostHogCookie;
+	} catch {
+		return null;
+	}
+}
+
+export function buildAnalyticHeaders(cookies: Cookies, url: URL): Headers {
+	const headers = new Headers();
+	const ph = readPostHogCookie(cookies);
+	if (ph?.distinct_id) headers.set('X-PostHog-Distinct-Id', ph.distinct_id);
+	const sessionId = ph?.$sesid?.[1];
+	if (sessionId) headers.set('X-PostHog-Session-Id', sessionId);
+	if (isInternalHost(url.hostname)) headers.set('X-Internal-Request', 'true');
+	return headers;
+}

--- a/src/lib/utils/analytics.test.ts
+++ b/src/lib/utils/analytics.test.ts
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('posthog-js', () => ({
 	default: {
 		capture: vi.fn(),
-		get_distinct_id: vi.fn().mockReturnValue('test-distinct-id')
+		get_distinct_id: vi.fn().mockReturnValue('test-distinct-id'),
+		get_session_id: vi.fn().mockReturnValue('test-session-id')
 	}
 }));
 
@@ -12,7 +13,7 @@ vi.mock('$app/environment', () => ({
 }));
 
 import posthog from 'posthog-js';
-import { trackEvent, isInternalUser, getDistinctId } from './analytics';
+import { trackEvent, isInternalUser, getDistinctId, getSessionId } from './analytics';
 
 describe('analytics', () => {
 	beforeEach(() => {
@@ -116,6 +117,35 @@ describe('analytics', () => {
 
 				// When: getting the distinct ID on the server
 				const result = serverGetDistinctId();
+
+				// Then: should return undefined
+				expect(result).toBeUndefined();
+			});
+		});
+
+		describe('getSessionId', () => {
+			it('should return the PostHog session ID in browser context', () => {
+				// Given: a browser environment with an active PostHog session
+
+				// When: getting the session ID
+				const result = getSessionId();
+
+				// Then: should return the PostHog-generated session ID
+				expect(result).toBe('test-session-id');
+			});
+
+			it('should return undefined when not in browser', async () => {
+				// Given: a server environment
+				vi.resetModules();
+				vi.doMock('$app/environment', () => ({ browser: false }));
+				vi.doMock('posthog-js', () => ({
+					default: { capture: vi.fn(), get_session_id: vi.fn() }
+				}));
+
+				const { getSessionId: serverGetSessionId } = await import('./analytics');
+
+				// When: getting the session ID on the server
+				const result = serverGetSessionId();
 
 				// Then: should return undefined
 				expect(result).toBeUndefined();

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -1,15 +1,23 @@
 import posthog from 'posthog-js';
 import { browser } from '$app/environment';
 
+export function isInternalHost(hostname: string): boolean {
+	return hostname.includes('localhost') || hostname === 'staging.jaccountable.org';
+}
+
 export function isInternalUser(): boolean {
 	if (!browser) return false;
-	const { hostname } = window.location;
-	return hostname.includes('localhost') || hostname === 'staging.jaccountable.org';
+	return isInternalHost(window.location.hostname);
 }
 
 export function getDistinctId(): string | undefined {
 	if (!browser) return undefined;
 	return posthog.get_distinct_id();
+}
+
+export function getSessionId(): string | undefined {
+	if (!browser) return undefined;
+	return posthog.get_session_id();
 }
 
 export function trackEvent(eventName: string, properties: Record<string, unknown> = {}): void {

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -2,8 +2,9 @@ import type { PageServerLoad } from './$types';
 import type { Article, EntitySummary, MetricsResponse } from '$lib/api/types';
 import { env as privateEnv } from '$env/dynamic/private';
 import { env as publicEnv } from '$env/dynamic/public';
+import { buildAnalyticHeaders } from '$lib/server/analytics';
 
-export const load: PageServerLoad = async ({ fetch }) => {
+export const load: PageServerLoad = async ({ fetch, cookies, url }) => {
 	// In Docker, the browser can reach the API at localhost but the container cannot —
 	// inside a container, localhost refers to the container itself, not the host machine.
 	// INTERNAL_API_BASE_URL lets the server use a container-reachable URL (e.g.
@@ -11,11 +12,12 @@ export const load: PageServerLoad = async ({ fetch }) => {
 	// browser-reachable URL. Falls back to PUBLIC_API_BASE_URL in production where
 	// both use the same public host.
 	const base = privateEnv.INTERNAL_API_BASE_URL ?? publicEnv.PUBLIC_API_BASE_URL ?? '';
+	const headers = buildAnalyticHeaders(cookies, url);
 
 	const [articlesRes, entitiesRes, metricsRes] = await Promise.all([
-		fetch(`${base}/api/v1/articles?sort=published_date&order=desc&page_size=5&page=1`),
-		fetch(`${base}/api/v1/entities?sort=most_found&page_size=8`),
-		fetch(`${base}/api/v1/metrics`)
+		fetch(`${base}/api/v1/articles?sort=published_date&order=desc&page_size=5&page=1`, { headers }),
+		fetch(`${base}/api/v1/entities?sort=most_found&page_size=8`, { headers }),
+		fetch(`${base}/api/v1/metrics`, { headers })
 	]);
 
 	const articlesData = articlesRes.ok ? await articlesRes.json() : null;

--- a/src/routes/articles/[id]/+page.server.ts
+++ b/src/routes/articles/[id]/+page.server.ts
@@ -3,13 +3,15 @@ import type { Article } from '$lib/api/types';
 import { error } from '@sveltejs/kit';
 import { env as privateEnv } from '$env/dynamic/private';
 import { env as publicEnv } from '$env/dynamic/public';
+import { buildAnalyticHeaders } from '$lib/server/analytics';
 
-export const load: PageServerLoad = async ({ fetch, params }) => {
+export const load: PageServerLoad = async ({ fetch, params, cookies, url }) => {
 	const base = privateEnv.INTERNAL_API_BASE_URL ?? publicEnv.PUBLIC_API_BASE_URL ?? '';
+	const headers = buildAnalyticHeaders(cookies, url);
 
 	const [res, relatedRes] = await Promise.all([
-		fetch(`${base}/api/v1/articles/${params.id}`),
-		fetch(`${base}/api/v1/articles/${params.id}/related?limit=4`).catch(() => null)
+		fetch(`${base}/api/v1/articles/${params.id}`, { headers }),
+		fetch(`${base}/api/v1/articles/${params.id}/related?limit=4`, { headers }).catch(() => null)
 	]);
 
 	if (res.status === 404 || res.status === 422) {


### PR DESCRIPTION
So backend `posthog.capture()` calls can attach `$session_id` and stitch into the same session as client-side events, resolving the PostHog warning about server-side conversion events missing a session ID.

Server-side +page.server.ts loads bypass apiFetch, so backend events captured during SSR (e.g. article:detail_view) were missing $session_id. Parse the PostHog cookie in a new $lib/server/analytics helper and forward the same three headers (distinct ID, session ID, internal flag) on every backend fetch from server loads.

Issues:
closes #131