### PR TITLE
feat(article): add per-article share button to ArticleCard

### DIFF
--- a/src/lib/components/features/home/ArticleCard.svelte
+++ b/src/lib/components/features/home/ArticleCard.svelte
@@ -1,12 +1,27 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import { Share2, Check } from 'lucide-svelte';
 	import { resolve } from '$app/paths';
 	import type { Article } from '$lib/api/types';
 	import ArticleSourceHeader from '../ArticleSourceHeader.svelte';
 	import AnalysisAlert from '../AnalysisAlert.svelte';
+	import { shareArticle } from './article-card-share';
 
 	let { article, onTopicClick }: { article: Article; onTopicClick?: (entity: string) => void } =
 		$props();
+
+	let justCopied = $state(false);
+
+	async function handleShare() {
+		const result = await shareArticle(article);
+		if (result.method === 'clipboard') {
+			justCopied = true;
+			setTimeout(() => {
+				justCopied = false;
+			}, 2000);
+		}
+	}
 
 	const classification = $derived(article.classifications[0]);
 
@@ -146,6 +161,22 @@
 >
 	<Card.Header class="pb-3">
 		<ArticleSourceHeader {article} />
+		<Card.Action class="relative z-10">
+			<Button
+				variant="ghost"
+				size="icon-lg"
+				class="hover:bg-green-50 hover:text-green-700"
+				onclick={handleShare}
+				aria-label="Share article"
+				data-testid="article-share-button"
+			>
+				{#if justCopied}
+					<Check class="size-5" />
+				{:else}
+					<Share2 class="size-5" />
+				{/if}
+			</Button>
+		</Card.Action>
 	</Card.Header>
 
 	<Card.Content class="space-y-4 px-4 sm:px-6">

--- a/src/lib/components/features/home/ArticleCard.test.ts
+++ b/src/lib/components/features/home/ArticleCard.test.ts
@@ -1,5 +1,17 @@
-import { render, screen, fireEvent } from '@testing-library/svelte';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('posthog-js', () => ({
+	default: {
+		capture: vi.fn()
+	}
+}));
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+import posthog from 'posthog-js';
 import ArticleCard from './ArticleCard.svelte';
 import type { Article } from '$lib/api/types';
 
@@ -265,6 +277,106 @@ describe('ArticleCard', () => {
 
 		// And: should show trailing "..."
 		expect(paragraphs[0].textContent).toMatch(/\.\.\.$/);
+	});
+
+	describe('share button', () => {
+		let writeTextMock: ReturnType<typeof vi.fn>;
+		let shareMock: ReturnType<typeof vi.fn> | undefined;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			Object.defineProperty(window, 'location', {
+				value: {
+					href: 'https://example.com/',
+					origin: 'https://example.com',
+					hostname: 'example.com'
+				},
+				writable: true,
+				configurable: true
+			});
+
+			writeTextMock = vi.fn().mockResolvedValue(undefined);
+			Object.defineProperty(navigator, 'clipboard', {
+				value: { writeText: writeTextMock },
+				writable: true,
+				configurable: true
+			});
+		});
+
+		afterEach(() => {
+			if (shareMock) {
+				// @ts-expect-error — remove the optional navigator.share mock between tests
+				delete navigator.share;
+				shareMock = undefined;
+			}
+			vi.restoreAllMocks();
+		});
+
+		it('should call navigator.share with the in-app article URL when native share is available', async () => {
+			// Given: navigator.share is available
+			shareMock = vi.fn().mockResolvedValue(undefined);
+			Object.defineProperty(navigator, 'share', {
+				value: shareMock,
+				writable: true,
+				configurable: true
+			});
+			render(ArticleCard, { props: { article: gleanerArticle } });
+
+			// When: user clicks the share button
+			await fireEvent.click(screen.getByTestId('article-share-button'));
+
+			// Then: should invoke navigator.share with the /articles/{id} URL
+			await waitFor(() => {
+				expect(shareMock).toHaveBeenCalledWith({
+					title: gleanerArticle.title,
+					text: gleanerArticle.title,
+					url: `https://example.com/articles/${gleanerArticle.id}`
+				});
+			});
+
+			// And: should track the native share event
+			expect(posthog.capture).toHaveBeenCalledWith(
+				'share:article_native_share',
+				expect.objectContaining({ article_id: gleanerArticle.id })
+			);
+		});
+
+		it('should fall back to clipboard when navigator.share is unavailable', async () => {
+			// Given: navigator.share is not defined
+			render(ArticleCard, { props: { article: gleanerArticle } });
+
+			// When: user clicks the share button
+			await fireEvent.click(screen.getByTestId('article-share-button'));
+
+			// Then: should write the /articles/{id} URL to the clipboard
+			await waitFor(() => {
+				expect(writeTextMock).toHaveBeenCalledWith(
+					`https://example.com/articles/${gleanerArticle.id}`
+				);
+			});
+
+			// And: should track the copy event
+			expect(posthog.capture).toHaveBeenCalledWith(
+				'share:article_copy_url',
+				expect.objectContaining({ article_id: gleanerArticle.id })
+			);
+		});
+
+		it('should swap the share icon for a check after a successful clipboard copy', async () => {
+			// Given: navigator.share is unavailable so we hit the clipboard fallback
+			const { container } = render(ArticleCard, { props: { article: gleanerArticle } });
+
+			// When: user clicks the share button
+			await fireEvent.click(screen.getByTestId('article-share-button'));
+
+			// Then: should render the check icon inside the share button
+			await waitFor(() => {
+				const button = screen.getByTestId('article-share-button');
+				expect(button.querySelector('.lucide-check')).not.toBeNull();
+			});
+			expect(container).toBeTruthy();
+		});
 	});
 
 	it('should handle empty classifications array', () => {

--- a/src/lib/components/features/home/article-card-share.ts
+++ b/src/lib/components/features/home/article-card-share.ts
@@ -1,0 +1,42 @@
+import type { Article } from '$lib/api/types';
+import { trackEvent } from '$lib/utils/analytics';
+
+export type ShareMethod = 'native' | 'clipboard' | 'failed';
+
+export interface ShareArticleResult {
+	method: ShareMethod;
+}
+
+function buildShareUrl(articleId: string): string {
+	return `${window.location.origin}/articles/${articleId}`;
+}
+
+export async function shareArticle(article: Article): Promise<ShareArticleResult> {
+	const shareUrl = buildShareUrl(article.id);
+
+	if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+		try {
+			await navigator.share({
+				title: article.title,
+				text: article.title,
+				url: shareUrl
+			});
+			trackEvent('share:article_native_share', { article_id: article.id });
+			return { method: 'native' };
+		} catch (err) {
+			if (err instanceof Error && err.name === 'AbortError') {
+				return { method: 'failed' };
+			}
+			console.error('Native share failed:', err);
+		}
+	}
+
+	try {
+		await navigator.clipboard.writeText(shareUrl);
+		trackEvent('share:article_copy_url', { article_id: article.id });
+		return { method: 'clipboard' };
+	} catch (err) {
+		console.error('Failed to copy article URL:', err);
+		return { method: 'failed' };
+	}
+}


### PR DESCRIPTION
Uses the Web Share API on mobile and supporting desktop browsers (falling back to clipboard) so readers can share a specific article via the OS share sheet. Shared URL points to /articles/[id] so link previews unfurl with article-specific OG metadata.

Issues:
closes #124