### PR TITLE
fix(analytics): read environment from runtime env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ SENTRY_AUTH_TOKEN='fake-token'
 PUBLIC_USE_REAL_API=false
 # Backend API base URL — empty in development (Vite proxy handles /api/*), set in staging/production
 PUBLIC_API_BASE_URL=
+# App environment label, forwarded to analytics events (development | staging | production). Set per-deploy as a Render runtime env var.
+PUBLIC_APP_ENV=development
 # Node server port (adapter-node runtime var — set when running `node build` on Render)
 PORT=3000
 # Node server origin (adapter-node runtime var — required to prevent CSRF errors)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -49,6 +49,7 @@ jobs:
       PUBLIC_USE_REAL_API: false # not used during CI. Only applicable for local development
       PUBLIC_SENTRY_DSN: 'fake-dsn-for-ci'
       PUBLIC_API_BASE_URL: 'https://doesnotmatter.com'
+      PUBLIC_APP_ENV: 'ci'
 
     steps:
       - name: Checkout

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -2,7 +2,13 @@ import * as Sentry from '@sentry/sveltekit';
 import posthog from 'posthog-js';
 import { env } from '$env/dynamic/public';
 
-const { PUBLIC_POSTHOG_API_HOST, PUBLIC_POSTHOG_KEY, PUBLIC_SENTRY_DSN, PUBLIC_USE_REAL_API } = env;
+const {
+	PUBLIC_POSTHOG_API_HOST,
+	PUBLIC_POSTHOG_KEY,
+	PUBLIC_SENTRY_DSN,
+	PUBLIC_USE_REAL_API,
+	PUBLIC_APP_ENV
+} = env;
 import type { ClientInit } from '@sveltejs/kit';
 
 export const init: ClientInit = async () => {
@@ -45,8 +51,7 @@ function initializeSentry(environment: string) {
 }
 
 function getEnvironment(): string {
-	const environment: string = import.meta.env.MODE;
-	return environment;
+	return PUBLIC_APP_ENV ?? '';
 }
 
 export const handleError = Sentry.handleErrorWithSentry();

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -1,5 +1,6 @@
 import posthog from 'posthog-js';
 import { browser } from '$app/environment';
+import { env } from '$env/dynamic/public';
 
 export function isInternalHost(hostname: string): boolean {
 	return hostname.includes('localhost') || hostname === 'staging.jaccountable.org';
@@ -24,7 +25,7 @@ export function trackEvent(eventName: string, properties: Record<string, unknown
 	if (!browser) return;
 
 	posthog.capture(eventName, {
-		environment: import.meta.env.MODE,
+		environment: env.PUBLIC_APP_ENV,
 		is_internal: isInternalUser(),
 		...properties
 	});

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -1,6 +1,10 @@
 import '@testing-library/jest-dom/vitest';
 import { server } from '$lib/mocks/server';
-import { beforeAll, afterEach, afterAll } from 'vitest';
+import { beforeAll, afterEach, afterAll, vi } from 'vitest';
+
+vi.mock('$env/dynamic/public', () => ({
+	env: { PUBLIC_APP_ENV: 'test' }
+}));
 
 // jsdom does not support the Web Animations API used by Svelte 5 transitions
 Element.prototype.animate = function () {


### PR DESCRIPTION
Vite bakes `import.meta.env.MODE` in at build time, so staging deploys of the production-mode image were tagging PostHog events with `environment: production`. Switch to PUBLIC_APP_ENV via $env/dynamic/public so the value is resolved per-request from Render runtime env.