### PR TITLE
feat(feedback): replace Google Form with UserJot widget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Used for Posthog analytics
 PUBLIC_POSTHOG_KEY=phc_your_posthog_project_key_here
+# UserJot widget project ID — feedback/roadmap/changelog widget
+PUBLIC_USERJOT_PROJECT_ID=your_userjot_project_id_here
 # PostHog reverse proxy host — set to your proxy URL in staging/production
 PUBLIC_POSTHOG_API_HOST=http://localhost:8080
 # Sentry DSN for error tracking

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -50,6 +50,7 @@ jobs:
       PUBLIC_SENTRY_DSN: 'fake-dsn-for-ci'
       PUBLIC_API_BASE_URL: 'https://doesnotmatter.com'
       PUBLIC_APP_ENV: 'ci'
+      PUBLIC_USERJOT_PROJECT_ID: 'fake-userjot-project-id-for-ci'
 
     steps:
       - name: Checkout

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -8,6 +8,18 @@ declare global {
 		// interface PageState {}
 		// interface Platform {}
 	}
+
+	interface UserJotSDK {
+		init: (projectId: string, options?: Record<string, unknown>) => void;
+		showWidget: (options?: { section?: 'feedback' | 'roadmap' | 'updates' }) => void;
+		hideWidget: () => void;
+		identify: (options: Record<string, unknown> | null) => void;
+	}
+
+	interface Window {
+		uj: UserJotSDK;
+		$ujq: unknown[];
+	}
 }
 
 export {};

--- a/src/app.html
+++ b/src/app.html
@@ -7,5 +7,26 @@
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>
+		<script>
+			window.$ujq = window.$ujq || [];
+			window.uj =
+				window.uj ||
+				new Proxy(
+					{},
+					{
+						get:
+							(_, p) =>
+							(...a) =>
+								window.$ujq.push([p, ...a])
+					}
+				);
+			document.head.appendChild(
+				Object.assign(document.createElement('script'), {
+					src: 'https://cdn.userjot.com/sdk/v2/uj.js',
+					type: 'module',
+					async: true
+				})
+			);
+		</script>
 	</body>
 </html>

--- a/src/lib/components/features/Footer.svelte
+++ b/src/lib/components/features/Footer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import logo from '$lib/assets/jaccountable-logo.png';
-	import { openContactForm } from '$lib/utils/contact';
+	import { openFeedbackWidget } from '$lib/utils/contact';
 	import { resolve } from '$app/paths';
 </script>
 
@@ -60,10 +60,10 @@
 					</li>
 					<li>
 						<button
-							onclick={openContactForm}
+							onclick={openFeedbackWidget}
 							class="uppercase text-muted-foreground hover:text-accent transition-colors duration-200 font-medium tracking-wide text-sm"
 						>
-							CONTACT
+							GIVE FEEDBACK
 						</button>
 					</li>
 				</ul>

--- a/src/lib/components/features/Footer.test.ts
+++ b/src/lib/components/features/Footer.test.ts
@@ -63,34 +63,30 @@ describe('Footer', () => {
 		expect(termsLink).toHaveAttribute('href', '/terms');
 	});
 
-	it('should display CONTACT link', () => {
+	it('should display GIVE FEEDBACK button', () => {
 		// Given: the footer renders
 		render(Footer);
 
 		// When: the page loads
 
-		// Then: should display CONTACT link
-		const contactButton = screen.getByRole('button', { name: /contact/i });
-		expect(contactButton).toBeInTheDocument();
-		expect(contactButton).toHaveClass('uppercase');
+		// Then: should display GIVE FEEDBACK button
+		const feedbackButton = screen.getByRole('button', { name: /give feedback/i });
+		expect(feedbackButton).toBeInTheDocument();
+		expect(feedbackButton).toHaveClass('uppercase');
 	});
 
-	it('should open Google Form when CONTACT is clicked', () => {
-		// Given: the footer renders
-		const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+	it('should open the UserJot widget when GIVE FEEDBACK is clicked', () => {
+		// Given: the footer renders with window.uj mocked
+		const showWidget = vi.fn();
+		(window as unknown as { uj: { showWidget: typeof showWidget } }).uj = { showWidget };
 		render(Footer);
 
-		// When: user clicks CONTACT
-		const contactButton = screen.getByRole('button', { name: /contact/i });
-		fireEvent.click(contactButton);
+		// When: user clicks GIVE FEEDBACK
+		const feedbackButton = screen.getByRole('button', { name: /give feedback/i });
+		fireEvent.click(feedbackButton);
 
-		// Then: should open Google Form in new tab
-		expect(windowOpenSpy).toHaveBeenCalledWith(
-			'https://forms.gle/nVwg2J3pQVBiPwuJ7',
-			'_blank',
-			'noopener,noreferrer'
-		);
-		windowOpenSpy.mockRestore();
+		// Then: should open the feedback widget
+		expect(showWidget).toHaveBeenCalledWith({ section: 'feedback' });
 	});
 
 	it('should display copyright notice', () => {

--- a/src/lib/components/features/home/ShareSection.test.ts
+++ b/src/lib/components/features/home/ShareSection.test.ts
@@ -18,12 +18,19 @@ import ShareSection from './ShareSection.svelte';
 describe('ShareSection', () => {
 	let windowOpenSpy: ReturnType<typeof vi.spyOn>;
 	let writeTextMock: ReturnType<typeof vi.fn>;
+	let showWidgetMock: ReturnType<typeof vi.fn>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 
 		// Mock window.open
 		windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+		// Mock UserJot widget SDK
+		showWidgetMock = vi.fn();
+		(window as unknown as { uj: { showWidget: typeof showWidgetMock } }).uj = {
+			showWidget: showWidgetMock
+		};
 
 		// Mock window.location
 		Object.defineProperty(window, 'location', {
@@ -362,20 +369,16 @@ describe('ShareSection', () => {
 		expect(screen.getByText('Tell us what you think')).toBeInTheDocument();
 	});
 
-	it('should open Google Form when feedback button is clicked', () => {
-		// Given: the share section component renders with window.open mocked
+	it('should open the UserJot feedback widget when feedback button is clicked', () => {
+		// Given: the share section component renders with window.uj mocked
 		render(ShareSection);
 
 		// When: user clicks the feedback button
 		const feedbackButton = screen.getByRole('button', { name: 'Tell us what you think' });
 		fireEvent.click(feedbackButton);
 
-		// Then: should open the Google Form with correct parameters
-		expect(windowOpenSpy).toHaveBeenCalledWith(
-			'https://forms.gle/nVwg2J3pQVBiPwuJ7',
-			'_blank',
-			'noopener,noreferrer'
-		);
+		// Then: should open the feedback widget
+		expect(showWidgetMock).toHaveBeenCalledWith({ section: 'feedback' });
 	});
 
 	it('should track share:feedback_button_click event when feedback button is clicked', () => {

--- a/src/lib/components/features/home/share-section.ts
+++ b/src/lib/components/features/home/share-section.ts
@@ -1,5 +1,5 @@
 import { trackEvent } from '$lib/utils/analytics';
-import { openContactForm } from '$lib/utils/contact';
+import { openFeedbackWidget } from '$lib/utils/contact';
 
 export function shareOnWhatsApp(shareMessage: string, shareUrl: string): void {
 	trackEvent('share:whatsapp_button_click');
@@ -38,5 +38,5 @@ export async function copyToClipboard(shareUrl: string): Promise<boolean> {
 
 export function handleFeedbackClick(): void {
 	trackEvent('share:feedback_button_click');
-	openContactForm();
+	openFeedbackWidget();
 }

--- a/src/lib/utils/contact.ts
+++ b/src/lib/utils/contact.ts
@@ -1,5 +1,4 @@
-export const CONTACT_FORM_URL = 'https://forms.gle/nVwg2J3pQVBiPwuJ7';
-
-export function openContactForm() {
-	window.open(CONTACT_FORM_URL, '_blank', 'noopener,noreferrer');
+export function openFeedbackWidget(): void {
+	if (typeof window === 'undefined' || !window.uj) return;
+	window.uj.showWidget({ section: 'feedback' });
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import { browser } from '$app/environment';
+	import { env } from '$env/dynamic/public';
 	import posthog from 'posthog-js';
 	import favicon from '$lib/assets/favicon-96x96.png';
 	import Header from '$lib/components/features/Header.svelte';
@@ -16,6 +18,16 @@
 		if (browser) {
 			posthog.capture('$pageview', { path: page.url.pathname });
 		}
+	});
+
+	onMount(() => {
+		const projectId = env.PUBLIC_USERJOT_PROJECT_ID;
+		if (!projectId) return;
+		window.uj.init(projectId, {
+			widget: true,
+			trigger: 'custom',
+			theme: 'auto'
+		});
 	});
 </script>
 


### PR DESCRIPTION
Wire the Footer "Give Feedback" button and the home page feedback button to open the UserJot widget (feedback, roadmap, changelog) instead of an external Google Form, keeping users in-product.

Issues:
closes #126