### PR TITLE
feat(seo): block crawlers on staging via dynamic robots.txt

### DIFF
--- a/src/routes/robots.txt/+server.ts
+++ b/src/routes/robots.txt/+server.ts
@@ -1,0 +1,8 @@
+import { env } from '$env/dynamic/public';
+
+export function GET() {
+	const body =
+		env.PUBLIC_APP_ENV === 'staging' ? 'User-agent: *\nDisallow: /' : 'User-agent: *\nDisallow:';
+
+	return new Response(body, { headers: { 'Content-Type': 'text/plain' } });
+}

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,0 @@
-# allow crawling everything by default
-User-agent: *
-Disallow:


### PR DESCRIPTION
Replaces the static robots.txt with a SvelteKit server route that returns Disallow: / on staging and stays permissive on production.

Issues:
closes #118