### PR TITLE
fix(article): scroll to top when navigating between related articles

### DIFF
--- a/src/routes/articles/[id]/+page.svelte
+++ b/src/routes/articles/[id]/+page.svelte
@@ -2,8 +2,15 @@
 	import ArticleDetailView from '$lib/components/features/article/ArticleDetailView.svelte';
 	import type { PageData } from './$types';
 	import { page } from '$app/state';
+	import { afterNavigate } from '$app/navigation';
 
 	let { data }: { data: PageData } = $props();
+
+	afterNavigate(({ from, to }) => {
+		if (from?.route.id === to?.route.id && from?.params?.id !== to?.params?.id) {
+			window.scrollTo(0, 0);
+		}
+	});
 
 	const description = $derived(
 		data.article.snippet


### PR DESCRIPTION
Same-route param changes preserved scroll position, causing related-article clicks to land mid-page on mobile.