### PR TITLE
fix(legal): remove duplicate footer on terms and privacy pages

### DIFF
--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import PrivacyPolicy from '$lib/content/legal/privacy-v1.svx';
-	import Footer from '$lib/components/features/Footer.svelte';
 </script>
 
 <section class="py-24 px-6">
@@ -12,7 +11,6 @@
 		</div>
 	</div>
 </section>
-<Footer />
 
 <style>
 	.privacy-content :global(h2) {

--- a/src/routes/privacy/privacy.test.ts
+++ b/src/routes/privacy/privacy.test.ts
@@ -35,15 +35,4 @@ describe('Privacy Page', () => {
 		const content = document.querySelector('.privacy-content');
 		expect(content).toBeInTheDocument();
 	});
-
-	it('should render the footer', () => {
-		// Given: the privacy page renders
-		render(PrivacyPage);
-
-		// When: the page loads
-
-		// Then: should render the footer
-		const footer = screen.getByRole('contentinfo');
-		expect(footer).toBeInTheDocument();
-	});
 });

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import TermsOfService from '$lib/content/legal/terms-of-service-v1.svx';
-	import Footer from '$lib/components/features/Footer.svelte';
 </script>
 
 <section class="py-24 px-6">
@@ -12,7 +11,6 @@
 		</div>
 	</div>
 </section>
-<Footer />
 
 <style>
 	.terms-content :global(h2) {

--- a/src/routes/terms/terms.test.ts
+++ b/src/routes/terms/terms.test.ts
@@ -35,15 +35,4 @@ describe('Terms Page', () => {
 		const content = document.querySelector('.terms-content');
 		expect(content).toBeInTheDocument();
 	});
-
-	it('should render the footer', () => {
-		// Given: the terms page renders
-		render(TermsPage);
-
-		// When: the page loads
-
-		// Then: should render the footer
-		const footer = screen.getByRole('contentinfo');
-		expect(footer).toBeInTheDocument();
-	});
 });


### PR DESCRIPTION
The root layout already renders <Footer /> on every non-error page, so the terms and privacy pages rendered a second footer of their own.